### PR TITLE
Add generic NJointRobotTypes, expose calibrate() method

### DIFF
--- a/include/robot_interfaces/finger.hpp
+++ b/include/robot_interfaces/finger.hpp
@@ -48,13 +48,10 @@
 
 namespace robot_interfaces
 {
-
 template <typename Type>
 using Timeseries = real_time_tools::ThreadsafeTimeseries<Type>;
 
 typedef Timeseries<int>::Index TimeIndex;
-
-
 
 /**
  * @brief Driver for interfacing the actual robot hardware or simulation.
@@ -76,7 +73,7 @@ class RobotDriver
 {
 public:
     RobotDriver(const double &max_action_duration_s,
-          const double &max_inter_action_duration_s)
+                const double &max_inter_action_duration_s)
         : max_action_duration_s_(max_action_duration_s),
           max_inter_action_duration_s_(max_inter_action_duration_s),
           is_shutdown_(false),
@@ -154,7 +151,6 @@ public:
     virtual Observation get_latest_observation() = 0;
 
 protected:
-
     /**
      * @brief Shut down the robot safely.
      *
@@ -232,7 +228,6 @@ private:
     std::shared_ptr<real_time_tools::RealTimeThread> thread_;
 };
 
-
 /**
  * @brief Contains all the input and output data of the robot.
  *
@@ -267,7 +262,8 @@ public:
     template <typename Type>
     using Ptr = std::shared_ptr<Type>;
 
-    RobotData(size_t history_length = 1000, bool use_shared_memory = false,
+    RobotData(size_t history_length = 1000,
+              bool use_shared_memory = false,
               std::string shared_memory_address = "")
     {
         if (use_shared_memory)
@@ -322,8 +318,9 @@ public:
     };
 
     // TODO add parameter: n_max_repeat_of_same_action
-    RobotBackend(std::shared_ptr<RobotDriver<Action, Observation>> robot,
-                std::shared_ptr<RobotData<Action, Observation, Status>> robot_data)
+    RobotBackend(
+        std::shared_ptr<RobotDriver<Action, Observation>> robot,
+        std::shared_ptr<RobotData<Action, Observation, Status>> robot_data)
         : robot_(robot),
           robot_data_(robot_data),
           destructor_was_called_(false),
@@ -339,8 +336,10 @@ public:
         thread_->join();
     }
 
-    int get_max_action_repetitions() { return max_action_repetitions_; }
-
+    int get_max_action_repetitions()
+    {
+        return max_action_repetitions_;
+    }
     void set_max_action_repetitions(const int &max_action_repetitions)
     {
         max_action_repetitions_ = max_action_repetitions;
@@ -473,7 +472,8 @@ public:
     typedef Timeseries<int>::Timestamp TimeStamp;
     typedef typename RobotBackend<Action, Observation>::Status Status;
 
-    RobotFrontend(std::shared_ptr<RobotData<Action, Observation, Status>> robot_data)
+    RobotFrontend(
+        std::shared_ptr<RobotData<Action, Observation, Status>> robot_data)
         : robot_data_(robot_data)
     {
     }
@@ -530,7 +530,6 @@ private:
     std::shared_ptr<RobotData<Action, Observation, Status>> robot_data_;
 };
 
-
 /**
  * @brief Collection of types for a generic N-joint BLMC robot.
  *
@@ -564,12 +563,11 @@ struct NJointRobotTypes
     typedef std::shared_ptr<Frontend> FrontendPtr;
 };
 
-
 /**
  * @brief Types for the Finger robot (basic 3-joint robot).
  */
 struct FingerTypes : public NJointRobotTypes<3>
-{};
-
+{
+};
 
 }  // namespace robot_interfaces

--- a/include/robot_interfaces/finger.hpp
+++ b/include/robot_interfaces/finger.hpp
@@ -129,6 +129,8 @@ public:
         return applied_action;
     }
 
+    virtual void calibrate() = 0;
+
 protected:
     /**
      * @brief Apply action immediately and block until it is executed.
@@ -342,6 +344,11 @@ public:
     void set_max_action_repetitions(const int &max_action_repetitions)
     {
         max_action_repetitions_ = max_action_repetitions;
+    }
+
+    void calibrate()
+    {
+        robot_->calibrate();
     }
 
 private:

--- a/include/robot_interfaces/finger.hpp
+++ b/include/robot_interfaces/finger.hpp
@@ -126,7 +126,7 @@ public:
         return applied_action;
     }
 
-    virtual void calibrate() = 0;
+    virtual void initialize() = 0;
 
 protected:
     /**
@@ -345,9 +345,9 @@ public:
         max_action_repetitions_ = max_action_repetitions;
     }
 
-    void calibrate()
+    void initialize()
     {
-        robot_->calibrate();
+        robot_->initialize();
     }
 
 private:

--- a/srcpy/py_finger.cpp
+++ b/srcpy/py_finger.cpp
@@ -21,30 +21,30 @@
 
 #include <robot_interfaces/finger.hpp>
 
-using namespace robot_interfaces::finger;
+using namespace robot_interfaces;
 
 PYBIND11_MODULE(py_finger, m)
 {
-    pybind11::class_<robot_interfaces::finger::Data,
-        robot_interfaces::finger::DataPtr>(m, "Data")
+    pybind11::class_<robot_interfaces::FingerTypes::Data,
+        robot_interfaces::FingerTypes::DataPtr>(m, "Data")
             .def(pybind11::init<>());
 
-    pybind11::class_<robot_interfaces::finger::Backend,
-        robot_interfaces::finger::BackendPtr>(m, "Backend");
+    pybind11::class_<robot_interfaces::FingerTypes::Backend,
+        robot_interfaces::FingerTypes::BackendPtr>(m, "Backend");
 
-    pybind11::class_<Observation>(m, "Observation")
-        .def_readwrite("angle", &Observation::angle)
-        .def_readwrite("velocity", &Observation::velocity)
-        .def_readwrite("torque", &Observation::torque);
+    pybind11::class_<FingerTypes::Observation>(m, "Observation")
+        .def_readwrite("angle", &FingerTypes::Observation::angle)
+        .def_readwrite("velocity", &FingerTypes::Observation::velocity)
+        .def_readwrite("torque", &FingerTypes::Observation::torque);
 
-    pybind11::class_<Frontend, FrontendPtr>(m, "Frontend")
-        .def(pybind11::init<robot_interfaces::finger::DataPtr>())
-        .def("get_observation", &Frontend::get_observation)
-        .def("get_desired_action", &Frontend::get_desired_action)
-        .def("get_applied_action", &Frontend::get_applied_action)
-        .def("get_time_stamp_ms", &Frontend::get_time_stamp_ms)
-        .def("append_desired_action", &Frontend::append_desired_action)
-        .def("wait_until_time_index", &Frontend::wait_until_timeindex)
-        .def("get_current_time_index", &Frontend::get_current_timeindex);
+    pybind11::class_<FingerTypes::Frontend, FingerTypes::FrontendPtr>(m, "Frontend")
+        .def(pybind11::init<robot_interfaces::FingerTypes::DataPtr>())
+        .def("get_observation", &FingerTypes::Frontend::get_observation)
+        .def("get_desired_action", &FingerTypes::Frontend::get_desired_action)
+        .def("get_applied_action", &FingerTypes::Frontend::get_applied_action)
+        .def("get_time_stamp_ms", &FingerTypes::Frontend::get_time_stamp_ms)
+        .def("append_desired_action", &FingerTypes::Frontend::append_desired_action)
+        .def("wait_until_time_index", &FingerTypes::Frontend::wait_until_timeindex)
+        .def("get_current_time_index", &FingerTypes::Frontend::get_current_timeindex);
 
 }

--- a/srcpy/py_finger.cpp
+++ b/srcpy/py_finger.cpp
@@ -30,7 +30,8 @@ PYBIND11_MODULE(py_finger, m)
             .def(pybind11::init<>());
 
     pybind11::class_<robot_interfaces::FingerTypes::Backend,
-        robot_interfaces::FingerTypes::BackendPtr>(m, "Backend");
+        robot_interfaces::FingerTypes::BackendPtr>(m, "Backend")
+            .def("calibrate", &FingerTypes::Backend::calibrate);
 
     pybind11::class_<FingerTypes::Observation>(m, "Observation")
         .def_readwrite("angle", &FingerTypes::Observation::angle)

--- a/srcpy/py_finger.cpp
+++ b/srcpy/py_finger.cpp
@@ -31,7 +31,7 @@ PYBIND11_MODULE(py_finger, m)
 
     pybind11::class_<robot_interfaces::FingerTypes::Backend,
         robot_interfaces::FingerTypes::BackendPtr>(m, "Backend")
-            .def("calibrate", &FingerTypes::Backend::calibrate);
+            .def("initialize", &FingerTypes::Backend::initialize);
 
     pybind11::class_<FingerTypes::Observation>(m, "Observation")
         .def_readwrite("angle", &FingerTypes::Observation::angle)


### PR DESCRIPTION
# Description
- Add a generic, templated `NJointRobotTypes<N>` structure that contains all the relevant types for a basic BLMC robot. Use this for the Finger instead of the `finger` namespace.
- Add `calibrate` to the `RobotDriver` interface and expose it through the `RobotBackend` class (needed so that the user can call it).

# How I Tested
By running demo_real_finger.py

# Do not merge
...before other related PRs are ready.