### PR TITLE
Extend `Action` for position controller

### DIFF
--- a/include/robot_interfaces/finger_logger.hpp
+++ b/include/robot_interfaces/finger_logger.hpp
@@ -152,10 +152,12 @@ public:
                             << observation.torque[0] << " , "
                             << observation.torque[1] << " , "
                             << observation.torque[2] << " , "
-                            << applied_action[0] << " , " << applied_action[1]
-                            << " , " << applied_action[2] << " , "
-                            << desired_action[0] << " , " << desired_action[1]
-                            << " , " << desired_action[2] << " , "
+                            << applied_action.torque[0] << " , "
+                            << applied_action.torque[1] << " , "
+                            << applied_action.torque[2] << " , "
+                            << desired_action.torque[0] << " , "
+                            << desired_action.torque[1] << " , "
+                            << desired_action.torque[2] << " , "
                             << status.action_repetitions << std::endl;
                     }
 

--- a/include/robot_interfaces/n_joint_robot_types.hpp
+++ b/include/robot_interfaces/n_joint_robot_types.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <cmath>
+
 #include <Eigen/Eigen>
 
 #include <robot_interfaces/robot_backend.hpp>
@@ -30,7 +32,135 @@ struct NJointRobotTypes
 {
     typedef Eigen::Matrix<double, N, 1> Vector;
 
-    typedef Vector Action;
+    struct Action
+    {
+        //! Desired torque command (in addition to position controller).
+        Vector torque;
+        //! Desired position.  Set to NaN to disable position controller.
+        Vector position;
+        //! P-gain for position controller.  If NaN, default is used.
+        Vector position_kp;
+        //! D-gain for position controller.  If NaN, default is used.
+        Vector position_kd;
+
+
+        /**
+         * @brief Create action with desired torque and (optional) position.
+         *
+         * The resulting torque command sent to the robot is
+         *
+         *     sent_torque = torque + PD(position)
+         *
+         * To disable the position controller, set the target position to NaN.
+         * The controller is executed joint-wise, so it is possible to run it
+         * only for some joints by setting a target position for these joints
+         * and setting the others to NaN.
+         *
+         * The specified torque is always added to the result of the position
+         * controller, so if you only want to run the position controller, make
+         * sure to set `torque` to zero for all joints.
+         *
+         * For more explicit code, the static factory methods `Troque`,
+         * `Position`, `TorqueAndPosition` and `Zero` should be used instead
+         * directly creating actions through this constuctor.
+         *
+         * @param torque  Desired torque.
+         * @param position  Desired position.  Set values to NaN to disable
+         *     position controller for the corresponding joints
+         * @param position_kp  P-gains for the position controller.  Set to NaN
+         *     to use default values.
+         * @param position_kd  D-gains for the position controller.  Set to NaN
+         *     to use default values.
+         */
+        Action(Vector torque = Vector::Zero(),
+               Vector position = None(),
+               Vector position_kp = None(),
+               Vector position_kd = None())
+            : torque(torque),
+              position(position),
+              position_kp(position_kp),
+              position_kd(position_kd)
+        {
+        }
+
+        /**
+         * @brief Create an action that only contains a torque command.
+         *
+         * @param torque  Desired torque.
+         *
+         * @return Pure "torque action".
+         */
+        static Action Torque(Vector torque)
+        {
+            return Action(torque);
+        }
+
+        /**
+         * @brief Create an action that only contains a position command.
+         *
+         * @param position Desired position.
+         * @param kp P-gain for position controller.  If not set, default is
+         *     used.  Set to NaN for specific joints to use default for this
+         *     joint.
+         * @param kd D-gain for position controller.  If not set, default is
+         *     used.  Set to NaN for specific joints to use default for this
+         *     joint.
+         *
+         * @return Pure "position action".
+         */
+        static Action Position(Vector position,
+                               Vector kp = None(),
+                               Vector kd = None())
+        {
+            return Action(Vector::Zero(), position, kp, kd);
+        }
+
+        /**
+         * @brief Create an action with both torque and position commands.
+         *
+         * @param torque Desired torque.
+         * @param position Desired position.  Set to NaN for specific joints to
+         *     disable position control for this joint.
+         * @param kp P-gain for position controller.  If not set, default is
+         *     used.  Set to NaN for specific joints to use default for this
+         *     joint.
+         * @param kd D-gain for position controller.  If not set, default is
+         *     used.  Set to NaN for specific joints to use default for this
+         *     joint.
+         *
+         * @return Action with both torque and position commands.
+         */
+        static Action TorqueAndPosition(Vector torque = Vector::Zero(),
+                                        Vector position = None(),
+                                        Vector position_kp = None(),
+                                        Vector position_kd = None())
+        {
+            return Action(
+                torque, position, position_kp, position_kd);
+        }
+
+        /**
+         * @brief Create a zero-torque action.
+         *
+         * @return Zero-torque action with position control disabled.
+         */
+        static Action Zero()
+        {
+            return Action();
+        }
+
+        /**
+         * @brief Create a NaN-Vector.  Helper function to set defaults for
+         *     position.
+         *
+         * @return Vector with all elements set to NaN.
+         */
+        static Vector None()
+        {
+            return Vector::Constant(std::numeric_limits<double>::quiet_NaN());
+        }
+    };
+
     struct Observation
     {
         Vector angle;
@@ -47,6 +177,6 @@ struct NJointRobotTypes
 
     typedef RobotFrontend<Action, Observation> Frontend;
     typedef std::shared_ptr<Frontend> FrontendPtr;
-};
+};  // namespace robot_interfaces
 
 }  // namespace robot_interfaces

--- a/srcpy/py_finger_types.cpp
+++ b/srcpy/py_finger_types.cpp
@@ -34,13 +34,27 @@ PYBIND11_MODULE(py_finger_types, m)
         FingerTypes::BackendPtr>(m, "Backend")
             .def("initialize", &FingerTypes::Backend::initialize);
 
+    pybind11::class_<FingerTypes::Action>(m, "Action")
+        .def_readwrite("torque", &FingerTypes::Action::torque)
+        .def_readwrite("position", &FingerTypes::Action::position)
+        .def_readwrite("position_kp", &FingerTypes::Action::position_kp)
+        .def_readwrite("position_kd", &FingerTypes::Action::position_kd)
+        .def(pybind11::init<FingerTypes::Vector,
+                            FingerTypes::Vector,
+                            FingerTypes::Vector,
+                            FingerTypes::Vector>(),
+             pybind11::arg("torque") = FingerTypes::Vector::Zero(),
+             pybind11::arg("position") = FingerTypes::Action::None(),
+             pybind11::arg("position_kp") = FingerTypes::Action::None(),
+             pybind11::arg("position_kd") = FingerTypes::Action::None());
+
     pybind11::class_<FingerTypes::Observation>(m, "Observation")
         .def_readwrite("angle", &FingerTypes::Observation::angle)
         .def_readwrite("velocity", &FingerTypes::Observation::velocity)
         .def_readwrite("torque", &FingerTypes::Observation::torque);
 
     pybind11::class_<FingerTypes::Frontend, FingerTypes::FrontendPtr>(m, "Frontend")
-        .def(pybind11::init<robot_interfaces::FingerTypes::DataPtr>())
+        .def(pybind11::init<FingerTypes::DataPtr>())
         .def("get_observation", &FingerTypes::Frontend::get_observation)
         .def("get_desired_action", &FingerTypes::Frontend::get_desired_action)
         .def("get_applied_action", &FingerTypes::Frontend::get_applied_action)

--- a/srcpy/py_one_joint_types.cpp
+++ b/srcpy/py_one_joint_types.cpp
@@ -33,6 +33,21 @@ PYBIND11_MODULE(py_one_joint_types, m)
         robot_interfaces::NJointRobotTypes<1>::BackendPtr>(m, "Backend")
             .def("initialize", &robot_interfaces::NJointRobotTypes<1>::Backend::initialize);
 
+    pybind11::class_<NJointRobotTypes<1>::Action>(m, "Action")
+        .def_readwrite("torque", &NJointRobotTypes<1>::Action::torque)
+        .def_readwrite("position", &NJointRobotTypes<1>::Action::position)
+        .def_readwrite("position_kp", &NJointRobotTypes<1>::Action::position_kp)
+        .def_readwrite("position_kd", &NJointRobotTypes<1>::Action::position_kd)
+        .def(
+            pybind11::init<NJointRobotTypes<1>::Vector,
+                           NJointRobotTypes<1>::Vector,
+                           NJointRobotTypes<1>::Vector,
+                           NJointRobotTypes<1>::Vector>(),
+            pybind11::arg("torque") = NJointRobotTypes<1>::Vector::Zero(),
+            pybind11::arg("position") = NJointRobotTypes<1>::Action::None(),
+            pybind11::arg("position_kp") = NJointRobotTypes<1>::Action::None(),
+            pybind11::arg("position_kd") = NJointRobotTypes<1>::Action::None());
+
     pybind11::class_<NJointRobotTypes<1>::Observation>(m, "Observation")
         .def_readwrite("angle", &NJointRobotTypes<1>::Observation::angle)
         .def_readwrite("velocity", &NJointRobotTypes<1>::Observation::velocity)


### PR DESCRIPTION
# Description
Extend the `Action` for the N-joint robot to include both torque and position commands.
This is needed for integrating the position controller into the interface.

Adapt FingerLogger to the change of the action format (currently only torque is logged, I did not spent more time on this as we anyway plan to make the logger more generic).

# How I Tested
By running demo applications on the Finger robot that use the position controller.

# Do not merge before
...related PR on blmc_robots is ready (need to be merged together).