### PR TITLE
status as regular struct

### DIFF
--- a/include/robot_interfaces/finger_logger.hpp
+++ b/include/robot_interfaces/finger_logger.hpp
@@ -31,7 +31,6 @@ class FingerLogger
 public:
     typedef FingerTypes::Action Action;
     typedef FingerTypes::Observation Observation;
-    typedef FingerTypes::Status Status;
 
     int block_size_;
     long int index_;

--- a/include/robot_interfaces/monitored_robot_driver.hpp
+++ b/include/robot_interfaces/monitored_robot_driver.hpp
@@ -168,9 +168,17 @@ private:
         // loop until shutdown and monitor action timing
         for (size_t t = 0; !is_shutdown_; t++)
         {
-            bool action_has_ended_on_time =
-                action_end_logger_.wait_for_timeindex(t,
-                                                      max_action_duration_s_);
+	  bool action_has_ended_on_time;
+	  if (max_action_duration_s_ >0)
+	    {
+	      action_has_ended_on_time = action_end_logger_.wait_for_timeindex(t,
+									       max_action_duration_s_);
+	    }
+	  else
+	    {
+	      action_has_ended_on_time = action_end_logger_.wait_for_timeindex(t);
+	    }
+	    
             if (!action_has_ended_on_time)
             {
                 std::cout
@@ -181,9 +189,15 @@ private:
                 return;
             }
 
-            bool action_has_started_on_time =
-                action_start_logger_.wait_for_timeindex(
-                    t + 1, max_inter_action_duration_s_);
+            bool action_has_started_on_time;
+	    if(max_inter_action_duration_s_>0)
+	      action_has_started_on_time = action_start_logger_.wait_for_timeindex(
+										   t + 1, max_inter_action_duration_s_);
+	    else
+	      {
+		action_has_started_on_time = action_start_logger_.wait_for_timeindex(
+										   t + 1);
+	      }
             if (!action_has_started_on_time)
             {
                 std::cout << "Action did not start on time, shutting down. Any "

--- a/include/robot_interfaces/n_joint_robot_types.hpp
+++ b/include/robot_interfaces/n_joint_robot_types.hpp
@@ -170,7 +170,6 @@ struct NJointRobotTypes
 
     typedef RobotBackend<Action, Observation> Backend;
     typedef std::shared_ptr<Backend> BackendPtr;
-    typedef typename Backend::Status Status;
 
     typedef RobotData<Action, Observation, Status> Data;
     typedef std::shared_ptr<Data> DataPtr;

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -23,6 +23,13 @@
 
 namespace robot_interfaces
 {
+
+    struct Status
+    {
+        uint32_t action_repetitions;
+    };
+
+  
 /**
  * @brief Communication link between RobotDriver and RobotData.
  *
@@ -37,10 +44,6 @@ template <typename Action, typename Observation>
 class RobotBackend
 {
 public:
-    struct Status
-    {
-        uint32_t action_repetitions;
-    };
 
     // TODO add parameter: n_max_repeat_of_same_action
     /**

--- a/include/robot_interfaces/robot_frontend.hpp
+++ b/include/robot_interfaces/robot_frontend.hpp
@@ -38,9 +38,6 @@ class RobotFrontend
 {
 public:
     typedef Timeseries<int>::Timestamp TimeStamp;
-    // TODO define Status somewhere else so we don't have an otherwise
-    // unnecessary dependency on RobotBackend here.
-    typedef typename RobotBackend<Action, Observation>::Status Status;
 
     RobotFrontend(
         std::shared_ptr<RobotData<Action, Observation, Status>> robot_data)


### PR DESCRIPTION
These lines:

https://github.com/open-dynamic-robot-initiative/robot_interfaces/blob/master/include/robot_interfaces/robot_backend.hpp#L40

https://github.com/open-dynamic-robot-initiative/robot_interfaces/blob/master/include/robot_interfaces/robot_backend.hpp#L55

confuses me a lot, because on one hand RobotData is templated with Status, but there is no choice on what class Status should be. 

Also Status is indirectly templated as a member of RobotBackend<Action,Observation>, which makes it difficult to access in a "static" way.

For example, the RobotData I am using is templated, and declaration should looks like this:

```
  template<int NB_DOFS>
  class Data : public robot_interfaces::RobotData< PressureAction<NB_DOFS>,
                                                   State<NB_DOFS>,
                                                   robot_interfaces::RobotBackend<PressureAction<NB_DOFS>, State<NB_DOFS>>Status >

```

which does not compile because robot_interfaces::RobotBackend<PressureAction<NB_DOFS>, State<NB_DOFS>> is not a type.

By moving Struct as a simple member of the namespace, I have this:

```
  template<int NB_DOFS>
  class Data : public robot_interfaces::RobotData< PressureAction<NB_DOFS>,
                                                   State<NB_DOFS>,
                                                   robot_interfaces::Status >
  {};

```

which compiles fine.

So this pull requests changes from

`robot_interfaces::RobotBackend<Action,Observation>::Status
`
to simpler:
`
robot_interfaces::Status`

But I guess there must be some reason for this complicated design, and I certainly overlooked it ? 