### PR TITLE
Add YAML conversion for Vector

### DIFF
--- a/include/robot_interfaces/finger_types.hpp
+++ b/include/robot_interfaces/finger_types.hpp
@@ -20,3 +20,13 @@ struct FingerTypes : public NJointRobotTypes<3>
 };
 
 }  // namespace robot_interfaces
+
+
+namespace YAML
+{
+template <>
+struct convert<robot_interfaces::FingerTypes::Vector>
+    : robot_interfaces::FingerTypes::yaml_convert_vector
+{
+};
+}  // namespace YAML

--- a/include/robot_interfaces/n_joint_robot_types.hpp
+++ b/include/robot_interfaces/n_joint_robot_types.hpp
@@ -11,6 +11,7 @@
 #include <cmath>
 
 #include <Eigen/Eigen>
+#include <yaml-cpp/yaml.h>
 
 #include <robot_interfaces/robot_backend.hpp>
 #include <robot_interfaces/robot_data.hpp>
@@ -177,6 +178,53 @@ struct NJointRobotTypes
 
     typedef RobotFrontend<Action, Observation> Frontend;
     typedef std::shared_ptr<Frontend> FrontendPtr;
+
+
+    /**
+     * @brief Vector-YAML converter to implement automatic YAML conversion.
+     *
+     * To implement automatic YAML de- and encoding for a specific n-joint type,
+     * simply use the following code snippet:
+     *
+     *     struct MyTypes : public NJointRobotTypes<42> {};
+     *
+     *     namespace YAML
+     *     {
+     *     template <>
+     *     struct convert<MyTypes::Vector> : MyTypes::yaml_convert_vector {};
+     *     }
+     */
+    struct yaml_convert_vector
+    {
+        static YAML::Node encode(const Vector &rhs)
+        {
+            YAML::Node node;
+
+            for (size_t i = 0; i < N; i++)
+            {
+                node.push_back(rhs[i]);
+            }
+
+            return node;
+        }
+
+        static bool decode(const YAML::Node &node, Vector &rhs)
+        {
+            if (!node.IsSequence() || node.size() != N)
+            {
+                return false;
+            }
+
+            for (size_t i = 0; i < N; i++)
+            {
+                rhs[i] = node[i].as<double>();
+            }
+
+            return true;
+        }
+    };
+
+
 };  // namespace robot_interfaces
 
 }  // namespace robot_interfaces

--- a/include/robot_interfaces/one_joint_types.hpp
+++ b/include/robot_interfaces/one_joint_types.hpp
@@ -1,0 +1,33 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2018-2019, Max Planck Gesellschaft
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <robot_interfaces/n_joint_robot_types.hpp>
+
+namespace robot_interfaces
+{
+/**
+ * @brief Types for the One-Joint robot.
+ */
+struct OneJointTypes : public NJointRobotTypes<1>
+{
+};
+
+}  // namespace robot_interfaces
+
+
+namespace YAML
+{
+template <>
+struct convert<robot_interfaces::OneJointTypes::Vector>
+    : robot_interfaces::OneJointTypes::yaml_convert_vector
+{
+};
+}  // namespace YAML
+

--- a/include/robot_interfaces/two_joint_types.hpp
+++ b/include/robot_interfaces/two_joint_types.hpp
@@ -1,0 +1,34 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2018-2019, Max Planck Gesellschaft
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <robot_interfaces/n_joint_robot_types.hpp>
+
+namespace robot_interfaces
+{
+/**
+ * @brief Types for the Two-Joint robot.
+ */
+struct TwoJointTypes : public NJointRobotTypes<2>
+{
+};
+
+}  // namespace robot_interfaces
+
+
+namespace YAML
+{
+template <>
+struct convert<robot_interfaces::TwoJointTypes::Vector>
+    : robot_interfaces::TwoJointTypes::yaml_convert_vector
+{
+};
+}  // namespace YAML
+
+

--- a/srcpy/py_one_joint_types.cpp
+++ b/srcpy/py_one_joint_types.cpp
@@ -19,48 +19,48 @@
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
 
-#include <robot_interfaces/n_joint_robot_types.hpp>
+#include <robot_interfaces/one_joint_types.hpp>
 
 using namespace robot_interfaces;
 
 PYBIND11_MODULE(py_one_joint_types, m)
 {
-    pybind11::class_<robot_interfaces::NJointRobotTypes<1>::Data,
-        robot_interfaces::NJointRobotTypes<1>::DataPtr>(m, "Data")
+    pybind11::class_<robot_interfaces::OneJointTypes::Data,
+        robot_interfaces::OneJointTypes::DataPtr>(m, "Data")
             .def(pybind11::init<>());
 
-    pybind11::class_<robot_interfaces::NJointRobotTypes<1>::Backend,
-        robot_interfaces::NJointRobotTypes<1>::BackendPtr>(m, "Backend")
-            .def("initialize", &robot_interfaces::NJointRobotTypes<1>::Backend::initialize);
+    pybind11::class_<robot_interfaces::OneJointTypes::Backend,
+        robot_interfaces::OneJointTypes::BackendPtr>(m, "Backend")
+            .def("initialize", &robot_interfaces::OneJointTypes::Backend::initialize);
 
-    pybind11::class_<NJointRobotTypes<1>::Action>(m, "Action")
-        .def_readwrite("torque", &NJointRobotTypes<1>::Action::torque)
-        .def_readwrite("position", &NJointRobotTypes<1>::Action::position)
-        .def_readwrite("position_kp", &NJointRobotTypes<1>::Action::position_kp)
-        .def_readwrite("position_kd", &NJointRobotTypes<1>::Action::position_kd)
+    pybind11::class_<OneJointTypes::Action>(m, "Action")
+        .def_readwrite("torque", &OneJointTypes::Action::torque)
+        .def_readwrite("position", &OneJointTypes::Action::position)
+        .def_readwrite("position_kp", &OneJointTypes::Action::position_kp)
+        .def_readwrite("position_kd", &OneJointTypes::Action::position_kd)
         .def(
-            pybind11::init<NJointRobotTypes<1>::Vector,
-                           NJointRobotTypes<1>::Vector,
-                           NJointRobotTypes<1>::Vector,
-                           NJointRobotTypes<1>::Vector>(),
-            pybind11::arg("torque") = NJointRobotTypes<1>::Vector::Zero(),
-            pybind11::arg("position") = NJointRobotTypes<1>::Action::None(),
-            pybind11::arg("position_kp") = NJointRobotTypes<1>::Action::None(),
-            pybind11::arg("position_kd") = NJointRobotTypes<1>::Action::None());
+            pybind11::init<OneJointTypes::Vector,
+                           OneJointTypes::Vector,
+                           OneJointTypes::Vector,
+                           OneJointTypes::Vector>(),
+            pybind11::arg("torque") = OneJointTypes::Vector::Zero(),
+            pybind11::arg("position") = OneJointTypes::Action::None(),
+            pybind11::arg("position_kp") = OneJointTypes::Action::None(),
+            pybind11::arg("position_kd") = OneJointTypes::Action::None());
 
-    pybind11::class_<NJointRobotTypes<1>::Observation>(m, "Observation")
-        .def_readwrite("position", &NJointRobotTypes<1>::Observation::position)
-        .def_readwrite("velocity", &NJointRobotTypes<1>::Observation::velocity)
-        .def_readwrite("torque", &NJointRobotTypes<1>::Observation::torque);
+    pybind11::class_<OneJointTypes::Observation>(m, "Observation")
+        .def_readwrite("position", &OneJointTypes::Observation::position)
+        .def_readwrite("velocity", &OneJointTypes::Observation::velocity)
+        .def_readwrite("torque", &OneJointTypes::Observation::torque);
 
-    pybind11::class_<NJointRobotTypes<1>::Frontend, NJointRobotTypes<1>::FrontendPtr>(m, "Frontend")
-        .def(pybind11::init<robot_interfaces::NJointRobotTypes<1>::DataPtr>())
-        .def("get_observation", &NJointRobotTypes<1>::Frontend::get_observation)
-        .def("get_desired_action", &NJointRobotTypes<1>::Frontend::get_desired_action)
-        .def("get_applied_action", &NJointRobotTypes<1>::Frontend::get_applied_action)
-        .def("get_time_stamp_ms", &NJointRobotTypes<1>::Frontend::get_time_stamp_ms)
-        .def("append_desired_action", &NJointRobotTypes<1>::Frontend::append_desired_action)
-        .def("wait_until_time_index", &NJointRobotTypes<1>::Frontend::wait_until_timeindex)
-        .def("get_current_time_index", &NJointRobotTypes<1>::Frontend::get_current_timeindex);
+    pybind11::class_<OneJointTypes::Frontend, OneJointTypes::FrontendPtr>(m, "Frontend")
+        .def(pybind11::init<robot_interfaces::OneJointTypes::DataPtr>())
+        .def("get_observation", &OneJointTypes::Frontend::get_observation)
+        .def("get_desired_action", &OneJointTypes::Frontend::get_desired_action)
+        .def("get_applied_action", &OneJointTypes::Frontend::get_applied_action)
+        .def("get_time_stamp_ms", &OneJointTypes::Frontend::get_time_stamp_ms)
+        .def("append_desired_action", &OneJointTypes::Frontend::append_desired_action)
+        .def("wait_until_time_index", &OneJointTypes::Frontend::wait_until_timeindex)
+        .def("get_current_time_index", &OneJointTypes::Frontend::get_current_timeindex);
 }
 

--- a/srcpy/py_two_joint_types.cpp
+++ b/srcpy/py_two_joint_types.cpp
@@ -19,47 +19,47 @@
 #include <pybind11/stl_bind.h>
 #include <pybind11/pybind11.h>
 
-#include <robot_interfaces/n_joint_robot_types.hpp>
+#include <robot_interfaces/two_joint_types.hpp>
 
 using namespace robot_interfaces;
 
 PYBIND11_MODULE(py_two_joint_types, m)
 {
-    pybind11::class_<robot_interfaces::NJointRobotTypes<2>::Data,
-        robot_interfaces::NJointRobotTypes<2>::DataPtr>(m, "Data")
+    pybind11::class_<robot_interfaces::TwoJointTypes::Data,
+        robot_interfaces::TwoJointTypes::DataPtr>(m, "Data")
             .def(pybind11::init<>());
 
-    pybind11::class_<robot_interfaces::NJointRobotTypes<2>::Backend,
-        robot_interfaces::NJointRobotTypes<2>::BackendPtr>(m, "Backend")
-            .def("initialize", &robot_interfaces::NJointRobotTypes<2>::Backend::initialize);
+    pybind11::class_<robot_interfaces::TwoJointTypes::Backend,
+        robot_interfaces::TwoJointTypes::BackendPtr>(m, "Backend")
+            .def("initialize", &robot_interfaces::TwoJointTypes::Backend::initialize);
 
-    pybind11::class_<NJointRobotTypes<2>::Action>(m, "Action")
-        .def_readwrite("torque", &NJointRobotTypes<2>::Action::torque)
-        .def_readwrite("position", &NJointRobotTypes<2>::Action::position)
-        .def_readwrite("position_kp", &NJointRobotTypes<2>::Action::position_kp)
-        .def_readwrite("position_kd", &NJointRobotTypes<2>::Action::position_kd)
+    pybind11::class_<TwoJointTypes::Action>(m, "Action")
+        .def_readwrite("torque", &TwoJointTypes::Action::torque)
+        .def_readwrite("position", &TwoJointTypes::Action::position)
+        .def_readwrite("position_kp", &TwoJointTypes::Action::position_kp)
+        .def_readwrite("position_kd", &TwoJointTypes::Action::position_kd)
         .def(
-            pybind11::init<NJointRobotTypes<2>::Vector,
-                           NJointRobotTypes<2>::Vector,
-                           NJointRobotTypes<2>::Vector,
-                           NJointRobotTypes<2>::Vector>(),
-            pybind11::arg("torque") = NJointRobotTypes<2>::Vector::Zero(),
-            pybind11::arg("position") = NJointRobotTypes<2>::Action::None(),
-            pybind11::arg("position_kp") = NJointRobotTypes<2>::Action::None(),
-            pybind11::arg("position_kd") = NJointRobotTypes<2>::Action::None());
+            pybind11::init<TwoJointTypes::Vector,
+                           TwoJointTypes::Vector,
+                           TwoJointTypes::Vector,
+                           TwoJointTypes::Vector>(),
+            pybind11::arg("torque") = TwoJointTypes::Vector::Zero(),
+            pybind11::arg("position") = TwoJointTypes::Action::None(),
+            pybind11::arg("position_kp") = TwoJointTypes::Action::None(),
+            pybind11::arg("position_kd") = TwoJointTypes::Action::None());
 
-    pybind11::class_<NJointRobotTypes<2>::Observation>(m, "Observation")
-        .def_readwrite("position", &NJointRobotTypes<2>::Observation::position)
-        .def_readwrite("velocity", &NJointRobotTypes<2>::Observation::velocity)
-        .def_readwrite("torque", &NJointRobotTypes<2>::Observation::torque);
+    pybind11::class_<TwoJointTypes::Observation>(m, "Observation")
+        .def_readwrite("position", &TwoJointTypes::Observation::position)
+        .def_readwrite("velocity", &TwoJointTypes::Observation::velocity)
+        .def_readwrite("torque", &TwoJointTypes::Observation::torque);
 
-    pybind11::class_<NJointRobotTypes<2>::Frontend, NJointRobotTypes<2>::FrontendPtr>(m, "Frontend")
-        .def(pybind11::init<robot_interfaces::NJointRobotTypes<2>::DataPtr>())
-        .def("get_observation", &NJointRobotTypes<2>::Frontend::get_observation)
-        .def("get_desired_action", &NJointRobotTypes<2>::Frontend::get_desired_action)
-        .def("get_applied_action", &NJointRobotTypes<2>::Frontend::get_applied_action)
-        .def("get_time_stamp_ms", &NJointRobotTypes<2>::Frontend::get_time_stamp_ms)
-        .def("append_desired_action", &NJointRobotTypes<2>::Frontend::append_desired_action)
-        .def("wait_until_time_index", &NJointRobotTypes<2>::Frontend::wait_until_timeindex)
-        .def("get_current_time_index", &NJointRobotTypes<2>::Frontend::get_current_timeindex);
+    pybind11::class_<TwoJointTypes::Frontend, TwoJointTypes::FrontendPtr>(m, "Frontend")
+        .def(pybind11::init<robot_interfaces::TwoJointTypes::DataPtr>())
+        .def("get_observation", &TwoJointTypes::Frontend::get_observation)
+        .def("get_desired_action", &TwoJointTypes::Frontend::get_desired_action)
+        .def("get_applied_action", &TwoJointTypes::Frontend::get_applied_action)
+        .def("get_time_stamp_ms", &TwoJointTypes::Frontend::get_time_stamp_ms)
+        .def("append_desired_action", &TwoJointTypes::Frontend::append_desired_action)
+        .def("wait_until_time_index", &TwoJointTypes::Frontend::wait_until_timeindex)
+        .def("get_current_time_index", &TwoJointTypes::Frontend::get_current_timeindex);
 }


### PR DESCRIPTION
# Description

Add a YAML conversion struct for `NJointRobotTypes::Vector` inside
`NJointRobotTypes` which can then easily be instantiated for the explicit
types.

Further explicitly define `OneJointTypes` and `TwoJointTypes` and add YAML conversions for the corresponding vectors.

# How I Tested
By using this to load robot configurations from YAML files (see https://github.com/open-dynamic-robot-initiative/blmc_robots/pull/24)