### PR TITLE
Add helper function to create Python bindings

### DIFF
--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -1,0 +1,85 @@
+/*
+ * Copyright [2017] Max Planck Society. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ * \brief Helper functions for creating Python bindings.
+ */
+#include <pybind11/eigen.h>
+#include <pybind11/stl_bind.h>
+#include <pybind11/pybind11.h>
+
+
+namespace robot_interfaces
+{
+
+/**
+ * \brief Create Python bindings for the specified robot Types.
+ *
+ * With this function, Python bindings can easily be created for new robots that
+ * are based on the NJointRobotTypes.  Example:
+ *
+ *     PYBIND11_MODULE(py_fortytwo_types, m)
+ *     {
+ *         create_python_bindings<NJointRobotTypes<42>>(m);
+ *     }
+ *
+ * \tparam Types  An instance of NJointRobotTypes.
+ * \param m  The second argument of the PYBIND11_MODULE macro.
+ */
+template <typename Types>
+void create_python_bindings(pybind11::module &m)
+{
+    pybind11::class_<typename Types::Data,
+        typename Types::DataPtr>(m, "Data")
+            .def(pybind11::init<>());
+
+    pybind11::class_<typename Types::Backend,
+        typename Types::BackendPtr>(m, "Backend")
+            .def("initialize", &Types::Backend::initialize);
+
+    pybind11::class_<typename Types::Action>(m, "Action")
+        .def_readwrite("torque", &Types::Action::torque)
+        .def_readwrite("position", &Types::Action::position)
+        .def_readwrite("position_kp", &Types::Action::position_kp)
+        .def_readwrite("position_kd", &Types::Action::position_kd)
+        .def(pybind11::init<typename Types::Vector,
+                            typename Types::Vector,
+                            typename Types::Vector,
+                            typename Types::Vector>(),
+             pybind11::arg("torque") = Types::Vector::Zero(),
+             pybind11::arg("position") = Types::Action::None(),
+             pybind11::arg("position_kp") = Types::Action::None(),
+             pybind11::arg("position_kd") = Types::Action::None());
+
+    pybind11::class_<typename Types::Observation>(m, "Observation")
+        .def_readwrite("position", &Types::Observation::position)
+        .def_readwrite("velocity", &Types::Observation::velocity)
+        .def_readwrite("torque", &Types::Observation::torque);
+
+    pybind11::class_<typename Types::Frontend, typename Types::FrontendPtr>(m, "Frontend")
+        .def(pybind11::init<typename Types::DataPtr>())
+        .def("get_observation", &Types::Frontend::get_observation)
+        .def("get_desired_action", &Types::Frontend::get_desired_action)
+        .def("get_applied_action", &Types::Frontend::get_applied_action)
+        .def("get_time_stamp_ms", &Types::Frontend::get_time_stamp_ms)
+        .def("append_desired_action", &Types::Frontend::append_desired_action)
+        .def("wait_until_time_index", &Types::Frontend::wait_until_timeindex)
+        .def("get_current_time_index", &Types::Frontend::get_current_timeindex);
+}
+
+}  // namespace

--- a/srcpy/py_finger_types.cpp
+++ b/srcpy/py_finger_types.cpp
@@ -15,55 +15,22 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <pybind11/eigen.h>
-#include <pybind11/stl_bind.h>
-#include <pybind11/pybind11.h>
-
+/**
+ * \file
+ * \brief Create bindings for One-Joint robot types
+ */
+#include <robot_interfaces/pybind_helper.hpp>
 #include <robot_interfaces/finger_types.hpp>
 #include <robot_interfaces/finger_logger.hpp>
+
 
 using namespace robot_interfaces;
 
 PYBIND11_MODULE(py_finger_types, m)
 {
-    pybind11::class_<FingerTypes::Data,
-        FingerTypes::DataPtr>(m, "Data")
-            .def(pybind11::init<>());
+    create_python_bindings<FingerTypes>(m);
 
-    pybind11::class_<FingerTypes::Backend,
-        FingerTypes::BackendPtr>(m, "Backend")
-            .def("initialize", &FingerTypes::Backend::initialize);
-
-    pybind11::class_<FingerTypes::Action>(m, "Action")
-        .def_readwrite("torque", &FingerTypes::Action::torque)
-        .def_readwrite("position", &FingerTypes::Action::position)
-        .def_readwrite("position_kp", &FingerTypes::Action::position_kp)
-        .def_readwrite("position_kd", &FingerTypes::Action::position_kd)
-        .def(pybind11::init<FingerTypes::Vector,
-                            FingerTypes::Vector,
-                            FingerTypes::Vector,
-                            FingerTypes::Vector>(),
-             pybind11::arg("torque") = FingerTypes::Vector::Zero(),
-             pybind11::arg("position") = FingerTypes::Action::None(),
-             pybind11::arg("position_kp") = FingerTypes::Action::None(),
-             pybind11::arg("position_kd") = FingerTypes::Action::None());
-
-    pybind11::class_<FingerTypes::Observation>(m, "Observation")
-        .def_readwrite("position", &FingerTypes::Observation::position)
-        .def_readwrite("velocity", &FingerTypes::Observation::velocity)
-        .def_readwrite("torque", &FingerTypes::Observation::torque);
-
-    pybind11::class_<FingerTypes::Frontend, FingerTypes::FrontendPtr>(m, "Frontend")
-        .def(pybind11::init<FingerTypes::DataPtr>())
-        .def("get_observation", &FingerTypes::Frontend::get_observation)
-        .def("get_desired_action", &FingerTypes::Frontend::get_desired_action)
-        .def("get_applied_action", &FingerTypes::Frontend::get_applied_action)
-        .def("get_time_stamp_ms", &FingerTypes::Frontend::get_time_stamp_ms)
-        .def("append_desired_action", &FingerTypes::Frontend::append_desired_action)
-        .def("wait_until_time_index", &FingerTypes::Frontend::wait_until_timeindex)
-        .def("get_current_time_index", &FingerTypes::Frontend::get_current_timeindex);
-
-    pybind11::class_<robot_interfaces::FingerLogger>(m, "FingerLogger")
+    pybind11::class_<FingerLogger>(m, "FingerLogger")
         .def(pybind11::init<FingerTypes::DataPtr, int, std::string>())
-        .def("run", &robot_interfaces::FingerLogger::run);
+        .def("run", &FingerLogger::run);
 }

--- a/srcpy/py_one_joint_types.cpp
+++ b/srcpy/py_one_joint_types.cpp
@@ -15,52 +15,18 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <pybind11/eigen.h>
-#include <pybind11/stl_bind.h>
-#include <pybind11/pybind11.h>
-
+/**
+ * \file
+ * \brief Create bindings for One-Joint robot types
+ */
+#include <robot_interfaces/pybind_helper.hpp>
 #include <robot_interfaces/n_joint_robot_types.hpp>
+
 
 using namespace robot_interfaces;
 
 PYBIND11_MODULE(py_one_joint_types, m)
 {
-    pybind11::class_<robot_interfaces::NJointRobotTypes<1>::Data,
-        robot_interfaces::NJointRobotTypes<1>::DataPtr>(m, "Data")
-            .def(pybind11::init<>());
-
-    pybind11::class_<robot_interfaces::NJointRobotTypes<1>::Backend,
-        robot_interfaces::NJointRobotTypes<1>::BackendPtr>(m, "Backend")
-            .def("initialize", &robot_interfaces::NJointRobotTypes<1>::Backend::initialize);
-
-    pybind11::class_<NJointRobotTypes<1>::Action>(m, "Action")
-        .def_readwrite("torque", &NJointRobotTypes<1>::Action::torque)
-        .def_readwrite("position", &NJointRobotTypes<1>::Action::position)
-        .def_readwrite("position_kp", &NJointRobotTypes<1>::Action::position_kp)
-        .def_readwrite("position_kd", &NJointRobotTypes<1>::Action::position_kd)
-        .def(
-            pybind11::init<NJointRobotTypes<1>::Vector,
-                           NJointRobotTypes<1>::Vector,
-                           NJointRobotTypes<1>::Vector,
-                           NJointRobotTypes<1>::Vector>(),
-            pybind11::arg("torque") = NJointRobotTypes<1>::Vector::Zero(),
-            pybind11::arg("position") = NJointRobotTypes<1>::Action::None(),
-            pybind11::arg("position_kp") = NJointRobotTypes<1>::Action::None(),
-            pybind11::arg("position_kd") = NJointRobotTypes<1>::Action::None());
-
-    pybind11::class_<NJointRobotTypes<1>::Observation>(m, "Observation")
-        .def_readwrite("position", &NJointRobotTypes<1>::Observation::position)
-        .def_readwrite("velocity", &NJointRobotTypes<1>::Observation::velocity)
-        .def_readwrite("torque", &NJointRobotTypes<1>::Observation::torque);
-
-    pybind11::class_<NJointRobotTypes<1>::Frontend, NJointRobotTypes<1>::FrontendPtr>(m, "Frontend")
-        .def(pybind11::init<robot_interfaces::NJointRobotTypes<1>::DataPtr>())
-        .def("get_observation", &NJointRobotTypes<1>::Frontend::get_observation)
-        .def("get_desired_action", &NJointRobotTypes<1>::Frontend::get_desired_action)
-        .def("get_applied_action", &NJointRobotTypes<1>::Frontend::get_applied_action)
-        .def("get_time_stamp_ms", &NJointRobotTypes<1>::Frontend::get_time_stamp_ms)
-        .def("append_desired_action", &NJointRobotTypes<1>::Frontend::append_desired_action)
-        .def("wait_until_time_index", &NJointRobotTypes<1>::Frontend::wait_until_timeindex)
-        .def("get_current_time_index", &NJointRobotTypes<1>::Frontend::get_current_timeindex);
+    create_python_bindings<NJointRobotTypes<1>>(m);
 }
 

--- a/srcpy/py_two_joint_types.cpp
+++ b/srcpy/py_two_joint_types.cpp
@@ -15,51 +15,17 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#include <pybind11/eigen.h>
-#include <pybind11/stl_bind.h>
-#include <pybind11/pybind11.h>
-
+/**
+ * \file
+ * \brief Create bindings for Two-Joint robot types
+ */
+#include <robot_interfaces/pybind_helper.hpp>
 #include <robot_interfaces/n_joint_robot_types.hpp>
+
 
 using namespace robot_interfaces;
 
 PYBIND11_MODULE(py_two_joint_types, m)
 {
-    pybind11::class_<robot_interfaces::NJointRobotTypes<2>::Data,
-        robot_interfaces::NJointRobotTypes<2>::DataPtr>(m, "Data")
-            .def(pybind11::init<>());
-
-    pybind11::class_<robot_interfaces::NJointRobotTypes<2>::Backend,
-        robot_interfaces::NJointRobotTypes<2>::BackendPtr>(m, "Backend")
-            .def("initialize", &robot_interfaces::NJointRobotTypes<2>::Backend::initialize);
-
-    pybind11::class_<NJointRobotTypes<2>::Action>(m, "Action")
-        .def_readwrite("torque", &NJointRobotTypes<2>::Action::torque)
-        .def_readwrite("position", &NJointRobotTypes<2>::Action::position)
-        .def_readwrite("position_kp", &NJointRobotTypes<2>::Action::position_kp)
-        .def_readwrite("position_kd", &NJointRobotTypes<2>::Action::position_kd)
-        .def(
-            pybind11::init<NJointRobotTypes<2>::Vector,
-                           NJointRobotTypes<2>::Vector,
-                           NJointRobotTypes<2>::Vector,
-                           NJointRobotTypes<2>::Vector>(),
-            pybind11::arg("torque") = NJointRobotTypes<2>::Vector::Zero(),
-            pybind11::arg("position") = NJointRobotTypes<2>::Action::None(),
-            pybind11::arg("position_kp") = NJointRobotTypes<2>::Action::None(),
-            pybind11::arg("position_kd") = NJointRobotTypes<2>::Action::None());
-
-    pybind11::class_<NJointRobotTypes<2>::Observation>(m, "Observation")
-        .def_readwrite("position", &NJointRobotTypes<2>::Observation::position)
-        .def_readwrite("velocity", &NJointRobotTypes<2>::Observation::velocity)
-        .def_readwrite("torque", &NJointRobotTypes<2>::Observation::torque);
-
-    pybind11::class_<NJointRobotTypes<2>::Frontend, NJointRobotTypes<2>::FrontendPtr>(m, "Frontend")
-        .def(pybind11::init<robot_interfaces::NJointRobotTypes<2>::DataPtr>())
-        .def("get_observation", &NJointRobotTypes<2>::Frontend::get_observation)
-        .def("get_desired_action", &NJointRobotTypes<2>::Frontend::get_desired_action)
-        .def("get_applied_action", &NJointRobotTypes<2>::Frontend::get_applied_action)
-        .def("get_time_stamp_ms", &NJointRobotTypes<2>::Frontend::get_time_stamp_ms)
-        .def("append_desired_action", &NJointRobotTypes<2>::Frontend::append_desired_action)
-        .def("wait_until_time_index", &NJointRobotTypes<2>::Frontend::wait_until_timeindex)
-        .def("get_current_time_index", &NJointRobotTypes<2>::Frontend::get_current_timeindex);
+    create_python_bindings<NJointRobotTypes<2>>(m);
 }


### PR DESCRIPTION
# Description

Add the templated helper function `create_python_bindings` that is used
to easily create Python bindings for different NJointRobotTypes without
redundant code.

# How I Tested
- Verified demo scripts do not have import errors.
- Run demo_fake_finger.py
- Not yet tested on the robots but will do this before merging.