### PR TITLE
Remove Status from NJointRobotTypes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,13 @@ target_link_libraries(demo ${catkin_LIBRARIES})
 # python bindings #
 ###################
 
+# generic #
+pybind11_add_module(py_generic srcpy/py_generic.cpp)
+target_link_libraries(py_generic PRIVATE ${catkin_LIBRARIES})
+set_target_properties(py_generic PROPERTIES
+    LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
+install(TARGETS py_generic DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
+
 # finger #
 set(py_finger_types_SRC_FILES
   srcpy/py_finger_types.cpp

--- a/include/robot_interfaces/n_joint_robot_types.hpp
+++ b/include/robot_interfaces/n_joint_robot_types.hpp
@@ -231,9 +231,6 @@ struct NJointRobotTypes
     typedef RobotBackend<Action, Observation> Backend;
     typedef std::shared_ptr<Backend> BackendPtr;
 
-    // allows cleaner creation of python bindings in pybind_helper.hpp
-    typedef Status RobotStatus;
-
     typedef RobotData<Action, Observation, Status> Data;
     typedef std::shared_ptr<Data> DataPtr;
 

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -67,12 +67,10 @@ void create_python_bindings(pybind11::module &m)
              pybind11::arg("position_kd") = Types::Action::None());
 
     pybind11::class_<typename Types::Observation>(m, "Observation")
+        .def(pybind11::init<>())
         .def_readwrite("position", &Types::Observation::position)
         .def_readwrite("velocity", &Types::Observation::velocity)
         .def_readwrite("torque", &Types::Observation::torque);
-
-    pybind11::class_<typename Types::RobotStatus>(m, "Status")
-        .def_readwrite("action_repetitions", &Types::RobotStatus::action_repetitions);
 
     pybind11::class_<typename Types::Frontend, typename Types::FrontendPtr>(m, "Frontend")
         .def(pybind11::init<typename Types::DataPtr>())

--- a/python/robot_interfaces/__init__.py
+++ b/python/robot_interfaces/__init__.py
@@ -1,4 +1,7 @@
-import robot_interfaces.py_finger_types as finger
-import robot_interfaces.py_trifinger_types as trifinger
-import robot_interfaces.py_one_joint_types as one_joint
-import robot_interfaces.py_two_joint_types as two_joint
+# use "noqa" comments to silence flake8 warnings
+# F401 = unused import, F403 = complaint about `import *`.
+from robot_interfaces.py_generic import *  # noqa: F401,F403
+import robot_interfaces.py_finger_types as finger  # noqa: F401
+import robot_interfaces.py_trifinger_types as trifinger  # noqa: F401
+import robot_interfaces.py_one_joint_types as one_joint  # noqa: F401
+import robot_interfaces.py_two_joint_types as two_joint  # noqa: F401

--- a/srcpy/py_generic.cpp
+++ b/srcpy/py_generic.cpp
@@ -1,0 +1,34 @@
+/*
+ * Copyright [2017] Max Planck Society. All rights reserved.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * \file
+ * \brief Create bindings for generic types
+ */
+#include <robot_interfaces/pybind_helper.hpp>
+#include <robot_interfaces/status.hpp>
+
+using namespace robot_interfaces;
+
+PYBIND11_MODULE(py_generic, m)
+{
+    pybind11::class_<Status>(m, "Status")
+        .def(pybind11::init<>())
+        .def_readwrite("action_repetitions",
+                       &Status::action_repetitions);
+}
+


### PR DESCRIPTION
# Description
Apparently pybind11 has problems with creating multiple bindings of the same type.  Since `Status` is not templated anymore, it was exactly the same in all "types" modules.  This compiled without error but when importing two of the resulting modules (as happening in the `__init__.py`), it raised the following error: "ImportError: generic_type: type "Status" is already registered!".

## Changes done in the PR 
- To fix the issue mentioned above, move the binding of `Status` to a new module `py_generic`.
- To be consistent between Python and C++ remove the typedef from `NJointRobotTypes`.
- Add bindings for the constructor of `Status` and `Observation` so they can be instantiated in Python.

# How I Tested
- Verify `import robot_interfaces` does not raise an error.
- `rosrun blmc_robots demo_fake_finger.py`