### PR TITLE
Add function process_desired_action

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ target_link_libraries(demo ${catkin_LIBRARIES})
 #########################
 # manage the unit tests #
 #########################
+add_subdirectory(tests)
 
 ###################
 # python bindings #

--- a/include/robot_interfaces/n_joint_robot_functions.hpp
+++ b/include/robot_interfaces/n_joint_robot_functions.hpp
@@ -1,0 +1,131 @@
+///////////////////////////////////////////////////////////////////////////////
+// BSD 3-Clause License
+//
+// Copyright (C) 2018-2019, Max Planck Gesellschaft
+// Copyright note valid unless otherwise stated in individual files.
+// All rights reserved.
+///////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include "n_joint_robot_types.hpp"
+
+namespace robot_interfaces
+{
+/**
+ * @brief Collection of functions for a generic N-joint BLMC robot.
+ *
+ * Defines all the types needed to set up an interface to a generic N-joint BLMC
+ * robot that expects as Action a simple vector of N torque commands and
+ * provides N observations containing measured joint angle, velocity and torque.
+ *
+ * Defines some generic functions that can be used by all robots that are based
+ * on the `NJointRobotTypes`.
+ *
+ * @tparam N_JOINTS Number of joints the robot has.
+ */
+template <size_t N_JOINTS>
+struct NJointRobotFunctions
+{
+    using Types = NJointRobotTypes<N_JOINTS>;
+
+    /**
+     * @brief Process the desired action provided by the user.
+     *
+     * Takes the desired action from the user and does the following processing:
+     *
+     * ## 1. Run the position controller in case a target position is set.
+     *
+     *   If the target position is set to a value unequal to NaN for any joint,
+     *   a PD position controller is executed for this joint and the resulting
+     *   torque command is added to the torque command in the action.
+     *
+     *   If the P- and/or D-gains are set to a non-NaN value in the action, they
+     *   are used for the control.  NaN-values are replaced with the default
+     *   gains.
+     *
+     * ## 2. Apply safety checks.
+     *
+     *   - Limit the torque to the allowed maximum value.
+     *   - Dampen velocity using the given safety_kd gains.  Damping us done
+     *     joint-wise using this equation:
+     *
+     *         torque_damped = torque_desired - safety_kd * current_velocity
+     *
+     * The resulting action with modifications of all steps is returned.
+     *
+     * @param desired_action  Desired action given by the user.
+     * @param latest_observation  Latest observation from the robot.
+     * @param max_torque_Nm  Maximum allowed absolute torque.
+     * @param safety_kd  D-gain for velocity damping.
+     * @param default_position_control_kp  Default P-gain for position control.
+     * @param default_position_control_kd  Default D-gain for position control.
+     *
+     * @return Resulting action after applying all the processing.
+     */
+    static typename Types::Action process_desired_action(
+        const typename Types::Action &desired_action,
+        const typename Types::Observation &latest_observation,
+        const double max_torque_Nm,
+        const typename Types::Vector &safety_kd,
+        const typename Types::Vector &default_position_control_kp,
+        const typename Types::Vector &default_position_control_kd)
+    {
+        typename Types::Action processed_action;
+
+        processed_action.torque = desired_action.torque;
+        processed_action.position = desired_action.position;
+
+        // Position controller
+        // -------------------
+        // TODO: add position limits
+
+        // Run the position controller only if a target position is set for at
+        // least one joint.
+        if (!processed_action.position.array().isNaN().all())
+        {
+            // Replace NaN-values with default gains
+            processed_action.position_kp =
+                desired_action.position_kp.array().isNaN().select(
+                    default_position_control_kp, desired_action.position_kp);
+            processed_action.position_kd =
+                desired_action.position_kd.array().isNaN().select(
+                    default_position_control_kd, desired_action.position_kd);
+
+            typename Types::Vector position_error =
+                processed_action.position - latest_observation.position;
+
+            // simple PD controller
+            typename Types::Vector position_control_torque =
+                processed_action.position_kp.cwiseProduct(position_error) +
+                processed_action.position_kd.cwiseProduct(
+                    latest_observation.velocity);
+
+            // position_control_torque contains NaN for joints where target
+            // position is set to NaN!  Filter those out and set the torque to
+            // zero instead.
+            position_control_torque =
+                position_control_torque.array().isNaN().select(
+                    0, position_control_torque);
+
+            // Add result of position controller to the torque command
+            processed_action.torque += position_control_torque;
+        }
+
+        // Safety Checks
+        // -------------
+        // limit to configured maximum torque
+        processed_action.torque =
+            mct::clamp(processed_action.torque, -max_torque_Nm, max_torque_Nm);
+        // velocity damping to prevent too fast movements
+        processed_action.torque -=
+            safety_kd.cwiseProduct(latest_observation.velocity);
+        // after applying checks, make sure we are still below the max. torque
+        processed_action.torque =
+            mct::clamp(processed_action.torque, -max_torque_Nm, max_torque_Nm);
+
+        return processed_action;
+    }
+};
+
+}  // namespace robot_interfaces

--- a/include/robot_interfaces/n_joint_robot_types.hpp
+++ b/include/robot_interfaces/n_joint_robot_types.hpp
@@ -166,8 +166,8 @@ struct NJointRobotTypes
          *
          * @return Action with both torque and position commands.
          */
-        static Action TorqueAndPosition(Vector torque = Vector::Zero(),
-                                        Vector position = None(),
+        static Action TorqueAndPosition(Vector torque,
+                                        Vector position,
                                         Vector position_kp = None(),
                                         Vector position_kd = None())
         {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,21 @@
+###################
+## add unit tests #
+###################
+
+macro(create_unittest test_name)
+
+# create the executable
+catkin_add_gtest(${test_name}_ut
+  main.cpp
+  test_${test_name}.cpp
+)
+if(TARGET ${test_name}_ut)
+    # link the dependencies to it
+    target_link_libraries(${test_name}_ut
+        ${catkin_LIBRARIES}
+    )
+endif()
+
+endmacro(create_unittest test_name)
+
+create_unittest(process_action)

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,16 @@
+/**
+ * \file
+ * \brief gtest main
+ * \author Maximilien Naveau
+ * \date 2018
+ *
+ * Main file that runs all unittest using gtest
+ * @see https://git-amd.tuebingen.mpg.de/amd-clmc/ci_example/wikis/catkin:-how-to-implement-unit-tests
+ */
+
+#include <gtest/gtest.h>
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/tests/test_process_action.cpp
+++ b/tests/test_process_action.cpp
@@ -59,8 +59,8 @@ TEST_F(TestProcessDesiredAction, valid_torque_no_safety)
                                           default_position_control_kp,
                                           default_position_control_kd);
 
-    ASSERT_EQ(0.1, resulting_action.torque[0]);
-    ASSERT_EQ(0.2, resulting_action.torque[1]);
+    ASSERT_EQ(desired_torque[0], resulting_action.torque[0]);
+    ASSERT_EQ(desired_torque[1], resulting_action.torque[1]);
 }
 
 /**
@@ -83,8 +83,8 @@ TEST_F(TestProcessDesiredAction, exceed_max_torque_no_safety)
                                           default_position_control_kp,
                                           default_position_control_kd);
 
-    ASSERT_EQ(0.3, resulting_action.torque[0]);
-    ASSERT_EQ(-0.3, resulting_action.torque[1]);
+    ASSERT_EQ(max_torque_Nm, resulting_action.torque[0]);
+    ASSERT_EQ(-max_torque_Nm, resulting_action.torque[1]);
 }
 
 /**
@@ -107,10 +107,10 @@ TEST_F(TestProcessDesiredAction, velocity_damping_low_velocity)
     // joint 0 has positive velocity so expecting a reduced torque.
     // joint 1 has negative velocity so expecting an increased torque.
     // both should remain within the max. torque range.
-    ASSERT_LT(resulting_action.torque[0], 0.1);
-    ASSERT_GE(resulting_action.torque[0], -0.3);
-    ASSERT_GT(resulting_action.torque[1], 0.2);
-    ASSERT_LE(resulting_action.torque[1], 0.3);
+    ASSERT_LT(resulting_action.torque[0], desired_torque[0]);
+    ASSERT_GE(resulting_action.torque[0], -max_torque_Nm);
+    ASSERT_GT(resulting_action.torque[1], desired_torque[1]);
+    ASSERT_LE(resulting_action.torque[1], max_torque_Nm);
 }
 
 /**
@@ -139,10 +139,10 @@ TEST_F(TestProcessDesiredAction, velocity_damping_high_velocity)
     // joint 0 has positive velocity so expecting a reduced torque.
     // joint 1 has negative velocity so expecting an increased torque.
     // both should remain within the max. torque range.
-    ASSERT_LT(resulting_action.torque[0], 0.1);
-    ASSERT_GE(resulting_action.torque[0], -0.3);
-    ASSERT_GT(resulting_action.torque[1], 0.2);
-    ASSERT_LE(resulting_action.torque[1], 0.3);
+    ASSERT_LT(resulting_action.torque[0], desired_torque[0]);
+    ASSERT_GE(resulting_action.torque[0], -max_torque_Nm);
+    ASSERT_GT(resulting_action.torque[1], desired_torque[1]);
+    ASSERT_LE(resulting_action.torque[1], max_torque_Nm);
 }
 
 /**
@@ -171,10 +171,10 @@ TEST_F(TestProcessDesiredAction, position_controller_basic)
     // Just testing here if the torque command goes in the right direction
 
     ASSERT_LT(resulting_action.torque[0], 0.0);
-    ASSERT_GE(resulting_action.torque[0], -0.3);
+    ASSERT_GE(resulting_action.torque[0], -max_torque_Nm);
 
     ASSERT_GT(resulting_action.torque[1], 0.0);
-    ASSERT_LE(resulting_action.torque[1], 0.3);
+    ASSERT_LE(resulting_action.torque[1], max_torque_Nm);
 
     // verify that position and gains are set correctly in the returned action
     ASSERT_EQ(desired_position[0], resulting_action.position[0]);
@@ -210,7 +210,7 @@ TEST_F(TestProcessDesiredAction, position_controller_one_joint_only)
 
     // Just testing here if the torque command goes in the right direction
     ASSERT_LT(resulting_action.torque[0], 0.0);
-    ASSERT_GE(resulting_action.torque[0], -0.3);
+    ASSERT_GE(resulting_action.torque[0], -max_torque_Nm);
 
     // desired position for joint 1 is nan, so no torque should be generated
     ASSERT_EQ(0.0, resulting_action.torque[1]);
@@ -337,9 +337,9 @@ TEST_F(TestProcessDesiredAction, position_controller_and_torque)
 
     // Just testing here if the torque command goes in the right direction
 
-    ASSERT_LT(resulting_action.torque[0], -0.2);
-    ASSERT_GE(resulting_action.torque[0], -0.3);
+    ASSERT_LT(resulting_action.torque[0], desired_torque[0]);
+    ASSERT_GE(resulting_action.torque[0], -max_torque_Nm);
 
-    ASSERT_GT(resulting_action.torque[1], 0.2);
-    ASSERT_LE(resulting_action.torque[1], 0.3);
+    ASSERT_GT(resulting_action.torque[1], desired_torque[1]);
+    ASSERT_LE(resulting_action.torque[1], max_torque_Nm);
 }

--- a/tests/test_process_action.cpp
+++ b/tests/test_process_action.cpp
@@ -1,0 +1,345 @@
+/**
+ * @file
+ * @brief Test for processing of robot actions
+ * @copyright Copyright (c) 2019, New York University and Max Planck
+ *            Gesellschaft.
+ */
+#include <gtest/gtest.h>
+#include "robot_interfaces/n_joint_robot_functions.hpp"
+
+/**
+ * @brief Fixture for the tests of process_desired_action().
+ */
+class TestProcessDesiredAction : public ::testing::Test
+{
+protected:
+    using Functions = robot_interfaces::NJointRobotFunctions<2>;
+    using Types = Functions::Types;
+    using Vector = Types::Vector;
+
+    Types::Observation observation;
+    double max_torque_Nm;
+    Vector safety_kd;
+    Vector default_position_control_kp;
+    Vector default_position_control_kd;
+
+    void SetUp() override
+    {
+        // set some arbitrary default values.  Tests can overwrite specific
+        // values if needed.
+        observation.position << 12.34, -0.42;
+        observation.velocity << .4, -.2;
+        observation.torque << 0.3, -0.25;
+
+        max_torque_Nm = 0.3;
+        safety_kd << 0.1, 0.1;
+
+        default_position_control_kp << 3, 4;
+        default_position_control_kd << .3, .4;
+    }
+};
+
+/**
+ * @brief Test if a valid torque command is returned unchanged (no safety).
+ */
+TEST_F(TestProcessDesiredAction, valid_torque_no_safety)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    Vector desired_torque;
+    desired_torque << 0.1, 0.2;
+    Types::Action action = Types::Action::Torque(desired_torque);
+
+    Types::Action resulting_action =
+        Functions::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    ASSERT_EQ(0.1, resulting_action.torque[0]);
+    ASSERT_EQ(0.2, resulting_action.torque[1]);
+}
+
+/**
+ * @brief Test if clamping to max. torque is working.
+ */
+TEST_F(TestProcessDesiredAction, exceed_max_torque_no_safety)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    Vector desired_torque;
+    desired_torque << 0.5, -1.2;
+    Types::Action action = Types::Action::Torque(desired_torque);
+
+    Types::Action resulting_action =
+        Functions::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    ASSERT_EQ(0.3, resulting_action.torque[0]);
+    ASSERT_EQ(-0.3, resulting_action.torque[1]);
+}
+
+/**
+ * @brief Test velocity damping with low velocity
+ */
+TEST_F(TestProcessDesiredAction, velocity_damping_low_velocity)
+{
+    Vector desired_torque;
+    desired_torque << 0.1, 0.2;
+    Types::Action action = Types::Action::Torque(desired_torque);
+
+    Types::Action resulting_action =
+        Functions::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    // joint 0 has positive velocity so expecting a reduced torque.
+    // joint 1 has negative velocity so expecting an increased torque.
+    // both should remain within the max. torque range.
+    ASSERT_LT(resulting_action.torque[0], 0.1);
+    ASSERT_GE(resulting_action.torque[0], -0.3);
+    ASSERT_GT(resulting_action.torque[1], 0.2);
+    ASSERT_LE(resulting_action.torque[1], 0.3);
+}
+
+/**
+ * @brief Test velocity damping with very high velocity.
+ *
+ * This test ensures that torques cannot exceed the allowed max. torque due to
+ * the velocity damping.
+ */
+TEST_F(TestProcessDesiredAction, velocity_damping_high_velocity)
+{
+    // set very high velocity
+    observation.velocity << 4000, -2000;
+
+    Vector desired_torque;
+    desired_torque << 0.1, 0.2;
+    Types::Action action = Types::Action::Torque(desired_torque);
+
+    Types::Action resulting_action =
+        Functions::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    // joint 0 has positive velocity so expecting a reduced torque.
+    // joint 1 has negative velocity so expecting an increased torque.
+    // both should remain within the max. torque range.
+    ASSERT_LT(resulting_action.torque[0], 0.1);
+    ASSERT_GE(resulting_action.torque[0], -0.3);
+    ASSERT_GT(resulting_action.torque[1], 0.2);
+    ASSERT_LE(resulting_action.torque[1], 0.3);
+}
+
+/**
+ * @brief Test basic position controller (default gains, no velocity)
+ */
+TEST_F(TestProcessDesiredAction, position_controller_basic)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 0, 0;
+    observation.velocity << 0, 0;
+
+    Vector desired_position;
+    desired_position << -1, 1;
+    Types::Action action = Types::Action::Position(desired_position);
+
+    Types::Action resulting_action =
+        Functions::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    // Just testing here if the torque command goes in the right direction
+
+    ASSERT_LT(resulting_action.torque[0], 0.0);
+    ASSERT_GE(resulting_action.torque[0], -0.3);
+
+    ASSERT_GT(resulting_action.torque[1], 0.0);
+    ASSERT_LE(resulting_action.torque[1], 0.3);
+
+    // verify that position and gains are set correctly in the returned action
+    ASSERT_EQ(desired_position[0], resulting_action.position[0]);
+    ASSERT_EQ(desired_position[1], resulting_action.position[1]);
+    ASSERT_EQ(default_position_control_kp[0], resulting_action.position_kp[0]);
+    ASSERT_EQ(default_position_control_kp[1], resulting_action.position_kp[1]);
+    ASSERT_EQ(default_position_control_kd[0], resulting_action.position_kd[0]);
+    ASSERT_EQ(default_position_control_kd[1], resulting_action.position_kd[1]);
+}
+
+/**
+ * @brief Test position controller for only one joint.
+ */
+TEST_F(TestProcessDesiredAction, position_controller_one_joint_only)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 0, 0;
+    observation.velocity << 0, 0;
+
+    Vector desired_position;
+    desired_position << -1, std::numeric_limits<double>::quiet_NaN();
+    Types::Action action = Types::Action::Position(desired_position);
+
+    Types::Action resulting_action =
+        Functions::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    // Just testing here if the torque command goes in the right direction
+    ASSERT_LT(resulting_action.torque[0], 0.0);
+    ASSERT_GE(resulting_action.torque[0], -0.3);
+
+    // desired position for joint 1 is nan, so no torque should be generated
+    ASSERT_EQ(0.0, resulting_action.torque[1]);
+}
+
+/**
+ * @brief Test position control with velocity (i.e. verifying D-gain is working)
+ */
+TEST_F(TestProcessDesiredAction, position_controller_with_velocity)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 0, 0;
+    observation.velocity << 0, 0;
+
+    Vector desired_position;
+    // use low position change to not saturate torques
+    desired_position << -.01, .01;
+
+    Types::Action result_action_without_velocity =
+        Functions::process_desired_action(
+            Types::Action::Position(desired_position),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd);
+
+    observation.velocity << -.01, .01;
+
+    Types::Action result_action_with_velocity =
+        Functions::process_desired_action(
+            Types::Action::Position(desired_position),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd);
+
+    // Since velocity has same sign as position error, the resulting
+    // (absolute) torques should be higher
+    EXPECT_GT(result_action_without_velocity.torque[0],
+              result_action_with_velocity.torque[0]);
+    EXPECT_LT(result_action_without_velocity.torque[1],
+              result_action_with_velocity.torque[1]);
+}
+
+/**
+ * @brief Test position control with custom gains.
+ */
+TEST_F(TestProcessDesiredAction, position_controller_custom_gains)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 0, 0;
+    observation.velocity << 0, 0;
+
+    Vector desired_position, kp, kd;
+    // use low position change to not saturate torques with lower gains
+    desired_position << -.01, .01;
+    // set gains significantly higher than the default gains above
+    kp << 10, 10;
+    kd << 5, 5;
+
+    Types::Action resulting_action_default_gains =
+        Functions::process_desired_action(
+            Types::Action::Position(desired_position),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd);
+
+    Types::Action resulting_action_custom_gains =
+        Functions::process_desired_action(
+            Types::Action::Position(desired_position, kp, kd),
+            observation,
+            max_torque_Nm,
+            safety_kd,
+            default_position_control_kp,
+            default_position_control_kd);
+
+    // verify that custom gains are set in resulting action
+    EXPECT_EQ(kp[0], resulting_action_custom_gains.position_kp[0]);
+    EXPECT_EQ(kp[1], resulting_action_custom_gains.position_kp[1]);
+    EXPECT_EQ(kd[0], resulting_action_custom_gains.position_kd[0]);
+    EXPECT_EQ(kd[1], resulting_action_custom_gains.position_kd[1]);
+
+    // Since custom gains are higher, the resulting (absolute) torques should be
+    // higher
+    EXPECT_GT(resulting_action_default_gains.torque[0],
+              resulting_action_custom_gains.torque[0]);
+    EXPECT_LT(resulting_action_default_gains.torque[1],
+              resulting_action_custom_gains.torque[1]);
+}
+
+/**
+ * @brief Test combined torque and position control.
+ */
+TEST_F(TestProcessDesiredAction, position_controller_and_torque)
+{
+    // disable velocity damping for this test
+    safety_kd << 0., 0.;
+
+    observation.position << 0, 0;
+    observation.velocity << 0, 0;
+
+    Vector desired_torque;
+    desired_torque << -0.2, 0.2;
+    Vector desired_position;
+    desired_position << -.1, .1;
+    Types::Action action =
+        Types::Action::TorqueAndPosition(desired_torque, desired_position);
+
+    Types::Action resulting_action =
+        Functions::process_desired_action(action,
+                                          observation,
+                                          max_torque_Nm,
+                                          safety_kd,
+                                          default_position_control_kp,
+                                          default_position_control_kd);
+
+    // Just testing here if the torque command goes in the right direction
+
+    ASSERT_LT(resulting_action.torque[0], -0.2);
+    ASSERT_GE(resulting_action.torque[0], -0.3);
+
+    ASSERT_GT(resulting_action.torque[1], 0.2);
+    ASSERT_LE(resulting_action.torque[1], 0.3);
+}


### PR DESCRIPTION
## Description

Add a function `process_desired_action()` which contains the processing
of the action (position control and safety-checks) which was originally
implemented in the `NJointBlmcRobotDriver` class in blmc_robots.

The purpose of moving it here in a separate function is to be able to
use it in other places as well and to be more testable.

For a cleaner interface wrap the function in a templated struct
`NJointRobotFunctions` similar to the `NJointRobotTypes`.

Also add unit tests for this function (implementing those already payed off:
It revealed a bug that custom gains set by the user were simply ignored.
This is already fixed in the function provided here.

## How I Tested
By running the new unit tests (`catkin run_tests robot_interfaces`).