### PR TITLE
Add mechanism for error reporting from backend to frontend

### DIFF
--- a/demos/demo.cpp
+++ b/demos/demo.cpp
@@ -117,6 +117,11 @@ public:
     observation.values[1] = state_[1];
     return observation;
   }
+
+  std::string get_error()
+  {
+      return ""; // no error
+  }
     
   void shutdown(){}
 

--- a/include/robot_interfaces/monitored_robot_driver.hpp
+++ b/include/robot_interfaces/monitored_robot_driver.hpp
@@ -119,6 +119,11 @@ public:
         return robot_driver_->get_latest_observation();
     }
 
+    virtual std::string get_error()
+    {
+        return robot_driver_->get_error();
+    }
+
     /**
      * @brief Shut down the robot safely.
      *

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -9,20 +9,20 @@
 #pragma once
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
 #include <cstdint>
-#include <atomic>
 
 #include <real_time_tools/process_manager.hpp>
 #include <real_time_tools/thread.hpp>
 #include <real_time_tools/threadsafe/threadsafe_timeseries.hpp>
 #include <real_time_tools/timer.hpp>
 
+#include <robot_interfaces/loggable.hpp>
 #include <robot_interfaces/monitored_robot_driver.hpp>
 #include <robot_interfaces/robot_data.hpp>
 #include <robot_interfaces/robot_driver.hpp>
 #include <robot_interfaces/status.hpp>
-#include <robot_interfaces/loggable.hpp>
 
 namespace robot_interfaces
 {
@@ -40,7 +40,6 @@ template <typename Action, typename Observation>
 class RobotBackend
 {
 public:
-
     // TODO add parameter: n_max_repeat_of_same_action
     /**
      * @param robot_driver  Driver instance for the actual robot.  This is
@@ -55,9 +54,9 @@ public:
         const double max_action_duration_s,
         const double max_inter_action_duration_s)
         : robot_driver_(
-			robot_driver, max_action_duration_s, max_inter_action_duration_s),
+              robot_driver, max_action_duration_s, max_inter_action_duration_s),
           robot_data_(robot_data),
-	  destructor_was_called_(false),
+          destructor_was_called_(false),
           max_action_repetitions_(0)
     {
         thread_ = std::make_shared<real_time_tools::RealTimeThread>();
@@ -89,7 +88,7 @@ private:
     std::shared_ptr<RobotData<Action, Observation, Status>> robot_data_;
     std::atomic<bool> destructor_was_called_;
     uint32_t max_action_repetitions_;
-  
+
     std::vector<real_time_tools::Timer> timers_;
 
     std::shared_ptr<real_time_tools::RealTimeThread> thread_;
@@ -122,7 +121,6 @@ private:
 
         for (long int t = 0; !destructor_was_called_; t++)
         {
-
             // TODO: figure out latency stuff!! open /dev/cpu_dma_latency:
             // Permission denied
 
@@ -167,14 +165,14 @@ private:
             timers_[2].tac();
 
             timers_[3].tic();
-	    // early exit if destructor has been called 
-	    while (!robot_data_->desired_action->wait_for_timeindex(t, 0.1))
-	      {
-		  if(destructor_was_called_)
-		  {
-		      return;
-		  }
-	      }
+            // early exit if destructor has been called
+            while (!robot_data_->desired_action->wait_for_timeindex(t, 0.1))
+            {
+                if (destructor_was_called_)
+                {
+                    return;
+                }
+            }
             Action desired_action = (*robot_data_->desired_action)[t];
             timers_[3].tac();
             timers_[4].tic();

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -161,8 +161,25 @@ private:
                     status.action_repetitions = action_repetitions + 1;
                 }
             }
+
+            bool has_error = false;
+            std::string driver_error_msg = robot_driver_.get_error();
+            if (!driver_error_msg.empty())
+            {
+                status.error_status = Status::ErrorStatus::DRIVER_ERROR;
+                status.error_message = driver_error_msg;
+                has_error = true;
+            }
+
             robot_data_->status->append(status);
             timers_[2].tac();
+
+            // if there is an error, shut robot down and stop loop
+            if (has_error)
+            {
+                robot_driver_.shutdown();
+                return;
+            }
 
             timers_[3].tic();
             // early exit if destructor has been called

--- a/include/robot_interfaces/robot_driver.hpp
+++ b/include/robot_interfaces/robot_driver.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <string>
+
 namespace robot_interfaces
 {
 /**
@@ -57,6 +59,13 @@ public:
      * @return Observation
      */
     virtual Observation get_latest_observation() = 0;
+
+    /**
+     * @brief Get error message if there is any error.
+     *
+     * @return Returns an error message or an empty string if there is no error.
+     */
+    virtual std::string get_error() = 0;
 
     /**
      * @brief Shut down the robot safely.

--- a/include/robot_interfaces/robot_frontend.hpp
+++ b/include/robot_interfaces/robot_frontend.hpp
@@ -73,6 +73,27 @@ public:
 
     TimeIndex append_desired_action(const Action &desired_action)
     {
+        // check error state. do not allow appending actions if there is an
+        // error
+        if (robot_data_->status->length() > 0)
+        {
+            const Status status = robot_data_->status->newest_element();
+            switch (status.error_status)
+            {
+                case Status::ErrorStatus::NO_ERROR:
+                    break;
+                case Status::ErrorStatus::DRIVER_ERROR:
+                    throw std::runtime_error("Driver Error: " +
+                                             status.error_message);
+                case Status::ErrorStatus::BACKEND_ERROR:
+                    throw std::runtime_error("Backend Error: " +
+                                             status.error_message);
+                default:
+                    throw std::runtime_error("Unknown Error: " +
+                                             status.error_message);
+            }
+        }
+
         // since the timeseries has a finite memory, we need to make sure that
         // by appending new actions we do not forget about actions which have
         // not been applied yet

--- a/include/robot_interfaces/status.hpp
+++ b/include/robot_interfaces/status.hpp
@@ -16,16 +16,28 @@ namespace robot_interfaces
 {
 struct Status : public Loggable
 {
+    enum class ErrorStatus
+    {
+        NO_ERROR = 0,
+        DRIVER_ERROR,
+        BACKEND_ERROR
+    };
+
     uint32_t action_repetitions = 0;
+    ErrorStatus error_status = ErrorStatus::NO_ERROR;
+    std::string error_message;
 
     std::vector<std::string> get_name() override
     {
-        return {"Action_repetitions"};
+        return {"action_repetitions", "error_status"};
     }
 
     std::vector<std::vector<double>> get_data() override
     {
-        return {{static_cast<double>(action_repetitions)}};
+        // FIXME error message cannot be logged because only numeric types are
+        // supported
+        return {{static_cast<double>(action_repetitions)},
+                {static_cast<double>(error_status)}};
     }
 };
 

--- a/include/robot_interfaces/status.hpp
+++ b/include/robot_interfaces/status.hpp
@@ -8,28 +8,25 @@
 
 #pragma once
 
+#include <robot_interfaces/loggable.hpp>
 #include <string>
 #include <vector>
-#include <robot_interfaces/loggable.hpp>
 
 namespace robot_interfaces
 {
+struct Status : public Loggable
+{
+    uint32_t action_repetitions = 0;
 
-    struct Status : public Loggable
+    std::vector<std::string> get_name() override
     {
-    
-        uint32_t action_repetitions = 0;
-    
-        std::vector<std::string> get_name() override
-        {
-            return {"Action_repetitions"};
-        }
-    
-        std::vector<std::vector<double>> get_data() override
-        {
-            return {{static_cast<double>(action_repetitions)}};
-        }
-    
-    };
+        return {"Action_repetitions"};
+    }
 
-}
+    std::vector<std::vector<double>> get_data() override
+    {
+        return {{static_cast<double>(action_repetitions)}};
+    }
+};
+
+}  // namespace robot_interfaces

--- a/include/robot_interfaces/status.hpp
+++ b/include/robot_interfaces/status.hpp
@@ -6,6 +6,11 @@
 // All rights reserved.
 ///////////////////////////////////////////////////////////////////////////////
 
+/**
+ * @file
+ * @brief Defines the Status struct.
+ */
+
 #pragma once
 
 #include <robot_interfaces/loggable.hpp>
@@ -14,6 +19,12 @@
 
 namespace robot_interfaces
 {
+/**
+ * @brief Status information from the backend.
+ *
+ * This struct is used to report status information that is not directly
+ * robot-related from the backend to the frontend.
+ */
 struct Status : public Loggable
 {
     enum class ErrorStatus
@@ -23,8 +34,20 @@ struct Status : public Loggable
         BACKEND_ERROR
     };
 
+    /**
+     * @brief Number of times the current action has been repeated because no
+     * new action has been provided.
+     */
     uint32_t action_repetitions = 0;
+
+    //! @brief Indicates if there is an error and, if yes, in which component.
     ErrorStatus error_status = ErrorStatus::NO_ERROR;
+
+    /**
+     * @brief Message describing the error.
+     *
+     * Value is undefined if `error_status == NO_ERROR`.
+     */
     std::string error_message;
 
     std::vector<std::string> get_name() override

--- a/srcpy/py_generic.cpp
+++ b/srcpy/py_generic.cpp
@@ -26,9 +26,15 @@ using namespace robot_interfaces;
 
 PYBIND11_MODULE(py_generic, m)
 {
-    pybind11::class_<Status>(m, "Status")
-        .def(pybind11::init<>())
-        .def_readwrite("action_repetitions",
-                       &Status::action_repetitions);
+    pybind11::class_<Status> pystatus(m, "Status");
+    pystatus.def(pybind11::init<>())
+        .def_readwrite("action_repetitions", &Status::action_repetitions)
+        .def_readwrite("error_status", &Status::error_status)
+        .def_readwrite("error_message", &Status::error_message);
+
+    pybind11::enum_<Status::ErrorStatus>(pystatus, "ErrorStatus")
+        .value("NO_ERROR", Status::ErrorStatus::NO_ERROR)
+        .value("DRIVER_ERROR", Status::ErrorStatus::DRIVER_ERROR)
+        .value("BACKEND_ERROR", Status::ErrorStatus::BACKEND_ERROR);
 }
 


### PR DESCRIPTION
# Summary
Add mechanism to report errors from the driver/backend side to the frontend (= user).

# Details
Errors are reported through the already existing `Status` messages.  For this extend `Status` with two fields `error_status` (to check if there is an error and if yes from which component) and `error_message` (contains a human readable message in case of error).

For now, this is only used to forward board errors reported via CAN to the frontend. Error cases from the backend level (e.g. timing violation) will be added in following PRs.

The backend gets errors from the driver via a new method `RobotDriver::get_error()` which simply returns an error message.  An empty string is considered to mean "no error".  This design makes implementation pretty simple but I am not sure how nice it is, so I am happy to change this, if we come up with a better idea.

In case of an error, the backend writes it to the status and then shuts down.  Via the frontend, the user can read the status and thus see the error.  Further `append_desired_action` will throw an exception in case there is an error, so there is no way for the user to ignore it.

# Known Issues
The logger currently only supports numeric types (everything is cast to double), so we cannot log the error message.  I am not sure if this is really a problem as operation anyway stops with the error and the message should be available from the screen output.

# How I Tested
Partly with the broken TriFinger and later by simply writing a hard-coded error from the backend.

# Do not merge before
https://github.com/open-dynamic-robot-initiative/blmc_robots/pull/46 (should be merged together).