### PR TITLE
Use time series from package "time_series"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,11 +22,11 @@ set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 # Search for dependencies. #
 ############################
 set(CATKIN_PKGS ${CATKIN_PKGS}
-mpi_cmake_modules
-real_time_tools
-mpi_cpp_tools
-pybind11_catkin
-
+  mpi_cmake_modules
+  real_time_tools
+  mpi_cpp_tools
+  pybind11_catkin
+  time_series
 )
 find_package(catkin REQUIRED COMPONENTS ${CATKIN_PKGS})
 

--- a/include/robot_interfaces/monitored_robot_driver.hpp
+++ b/include/robot_interfaces/monitored_robot_driver.hpp
@@ -12,8 +12,8 @@
 
 #include <real_time_tools/process_manager.hpp>
 #include <real_time_tools/thread.hpp>
-#include <real_time_tools/threadsafe/threadsafe_timeseries.hpp>
 #include <real_time_tools/timer.hpp>
+#include <time_series/time_series.hpp>
 
 #include <robot_interfaces/robot_driver.hpp>
 
@@ -149,8 +149,8 @@ private:
     //! \brief Whether shutdown was initiated.
     bool is_shutdown_;  // TODO: should be atomic
 
-    real_time_tools::ThreadsafeTimeseries<bool> action_start_logger_;
-    real_time_tools::ThreadsafeTimeseries<bool> action_end_logger_;
+    time_series::TimeSeries<bool> action_start_logger_;
+    time_series::TimeSeries<bool> action_end_logger_;
 
     std::shared_ptr<real_time_tools::RealTimeThread> thread_;
 

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -15,7 +15,6 @@
 
 #include <real_time_tools/process_manager.hpp>
 #include <real_time_tools/thread.hpp>
-#include <real_time_tools/threadsafe/threadsafe_timeseries.hpp>
 #include <real_time_tools/timer.hpp>
 
 #include <robot_interfaces/loggable.hpp>

--- a/include/robot_interfaces/robot_data.hpp
+++ b/include/robot_interfaces/robot_data.hpp
@@ -12,12 +12,12 @@
 #include <memory>
 #include <string>
 
-#include <real_time_tools/threadsafe/threadsafe_timeseries.hpp>
+#include <time_series/time_series.hpp>
 
 namespace robot_interfaces
 {
 template <typename Type>
-using Timeseries = real_time_tools::ThreadsafeTimeseries<Type>;
+using Timeseries = time_series::TimeSeries<Type>;
 
 /**
  * @brief Contains all the input and output data of the robot.

--- a/include/robot_interfaces/robot_frontend.hpp
+++ b/include/robot_interfaces/robot_frontend.hpp
@@ -11,7 +11,7 @@
 #include <algorithm>
 #include <cmath>
 
-#include <real_time_tools/threadsafe/threadsafe_timeseries.hpp>
+#include <time_series/time_series.hpp>
 
 #include <robot_interfaces/robot_backend.hpp>
 #include <robot_interfaces/robot_data.hpp>
@@ -19,9 +19,9 @@
 namespace robot_interfaces
 {
 template <typename Type>
-using Timeseries = real_time_tools::ThreadsafeTimeseries<Type>;
+using Timeseries = time_series::TimeSeries<Type>;
 
-typedef Timeseries<int>::Index TimeIndex;
+typedef time_series::Index TimeIndex;
 
 /**
  * @brief Communication link between RobotData and the user.
@@ -37,7 +37,7 @@ template <typename Action, typename Observation>
 class RobotFrontend
 {
 public:
-    typedef Timeseries<int>::Timestamp TimeStamp;
+    typedef time_series::Timestamp TimeStamp;
 
     RobotFrontend(
         std::shared_ptr<RobotData<Action, Observation, Status>> robot_data)

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -21,7 +21,6 @@
 
 #include <real_time_tools/process_manager.hpp>
 #include <real_time_tools/thread.hpp>
-#include <real_time_tools/threadsafe/threadsafe_timeseries.hpp>
 #include <real_time_tools/timer.hpp>
 
 #include <robot_interfaces/loggable.hpp>

--- a/package.xml
+++ b/package.xml
@@ -1,25 +1,19 @@
 <?xml version="1.0"?>
-<package>
+<package format="2">
   <name>robot_interfaces</name>
   <version>1.0.0</version>
   <description>
-	This package provides C++ interfaces (purely virtual classes) for different robots. The idea is to use this interface both for the real robots as well as the simulators.
+    This package provides C++ interfaces (purely virtual classes) for different robots. The idea is to use this interface both for the real robots as well as the simulators.
   </description>
   <author email="manuel.wuthrich@gmail.com">Manuel Wuthrich</author>
   <maintainer email="manuel.wuthrich@gmail.com">Manuel Wuthrich</maintainer>
   <license>TODO</license>
   <buildtool_depend>catkin</buildtool_depend>
 
-  <build_depend> mpi_cmake_modules </build_depend>
-  <run_depend>   mpi_cmake_modules </run_depend>
-
-  <build_depend> real_time_tools </build_depend>
-  <run_depend>   real_time_tools </run_depend>
-
-  <build_depend> mpi_cpp_tools </build_depend>
-  <run_depend>   mpi_cpp_tools </run_depend>
-
-  <build_depend>pybind11_catkin</build_depend>
-  <run_depend>pybind11_catkin</run_depend>
+  <depend>mpi_cmake_modules</depend>
+  <depend>real_time_tools</depend>
+  <depend>mpi_cpp_tools</depend>
+  <depend>pybind11_catkin</depend>
+  <depend>time_series</depend>
 
 </package>


### PR DESCRIPTION
# Description
Use the time series implementation from the new time_series package
instead of the one from real_time_tools.

Note that this should not change behaviour, it simply uses the implementation from the new package instead of the old one.

# How I Tested
By running demo_fake_finger.py from blmc_robots.

# Do not merge before
...treep config is updated: https://github.com/machines-in-motion/treep_machines_in_motion/pull/4 and corresponding merge request in git-amd.