### PR TITLE
Report timing errors to frontend

### DIFF
--- a/include/robot_interfaces/monitored_robot_driver.hpp
+++ b/include/robot_interfaces/monitored_robot_driver.hpp
@@ -10,9 +10,9 @@
 
 #include <iostream>
 
-#include <mpi_cpp_tools/multithreading.hpp>
 #include <real_time_tools/process_manager.hpp>
 #include <real_time_tools/thread.hpp>
+#include <real_time_tools/threadsafe/threadsafe_object.hpp>
 #include <real_time_tools/timer.hpp>
 #include <time_series/time_series.hpp>
 
@@ -163,7 +163,7 @@ private:
 
     std::shared_ptr<real_time_tools::RealTimeThread> thread_;
 
-    MutexedType<std::string> error_message_;
+    real_time_tools::SingletypeThreadsafeObject<std::string, 1> error_message_;
 
     /**
      * @brief Monitor the timing of action execution.

--- a/include/robot_interfaces/monitored_robot_driver.hpp
+++ b/include/robot_interfaces/monitored_robot_driver.hpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 
+#include <mpi_cpp_tools/multithreading.hpp>
 #include <real_time_tools/process_manager.hpp>
 #include <real_time_tools/thread.hpp>
 #include <real_time_tools/timer.hpp>
@@ -124,7 +125,7 @@ public:
         const std::string driver_error = robot_driver_->get_error();
         if (driver_error.empty())
         {
-            return error_message_;
+            return error_message_.get();
         }
         else
         {
@@ -162,7 +163,7 @@ private:
 
     std::shared_ptr<real_time_tools::RealTimeThread> thread_;
 
-    std::string error_message_ = "";
+    MutexedType<std::string> error_message_;
 
     /**
      * @brief Monitor the timing of action execution.
@@ -188,7 +189,7 @@ private:
                                                       max_action_duration_s_);
             if (!action_has_ended_on_time)
             {
-                error_message_ = "Action did not end on time, shutting down.";
+                error_message_.set("Action did not end on time, shutting down.");
                 shutdown();
                 return;
             }
@@ -198,7 +199,7 @@ private:
                     t + 1, max_inter_action_duration_s_);
             if (!action_has_started_on_time)
             {
-                error_message_ = "Action did not start on time, shutting down.";
+                error_message_.set("Action did not start on time, shutting down.");
                 shutdown();
                 return;
             }

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -66,6 +66,13 @@ template <size_t NUM_CHECKPOINTS, bool ENABLED = true>
 class CheckpointTimer
 {
 public:
+    CheckpointTimer()
+    {
+        static_assert(NUM_CHECKPOINTS > 0,
+                      "CheckpointTimer needs at least one checkpoint");
+        checkpoint_names_[0] = "Total";
+    }
+
     //! @brief Start timer iteration.
     void start()
     {
@@ -109,12 +116,10 @@ public:
     {
         if (ENABLED)
         {
-            std::cout << "===== Total:" << std::endl;
-            timers_[0].print_statistics();
-
-            for (size_t i = 1; i < timers_.size(); i++)
+            std::cout << "======================================" << std::endl;
+            for (size_t i = 0; i < timers_.size(); i++)
             {
-                std::cout << "----- " << checkpoint_names_[i] << std::endl;
+                std::cout << "===== " << checkpoint_names_[i] << std::endl;
                 timers_[i].print_statistics();
             }
         }
@@ -325,7 +330,7 @@ private:
             robot_data_->applied_action->append(applied_action);
             timer_.checkpoint("append applied action");
 
-            if (t % 5000 == 0)
+            if (t % 5000 == 0 && t > 0)
             {
                 timer_.print_statistics();
             }

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -25,7 +25,6 @@
 
 namespace robot_interfaces
 {
-
 /**
  * @brief Timer to measure code execution time with "checkpoints"
  *
@@ -67,7 +66,6 @@ template <size_t NUM_CHECKPOINTS, bool ENABLED = true>
 class CheckpointTimer
 {
 public:
-
     //! @brief Start timer iteration.
     void start()
     {

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -109,7 +109,7 @@ private:
      */
     uint32_t max_action_repetitions_;
 
-    real_time_tools::CheckpointTimer<6, true> timer_;
+    real_time_tools::CheckpointTimer<6, false> timer_;
 
     std::shared_ptr<real_time_tools::RealTimeThread> thread_;
 

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -102,6 +102,13 @@ public:
             {
                 checkpoint_names_[current_checkpoint] = checkpoint_name;
             }
+            else if (checkpoint_names_[current_checkpoint] != checkpoint_name)
+            {
+                throw std::runtime_error("Wrong checkpoint called (expected '" +
+                                         checkpoint_names_[current_checkpoint] +
+                                         "' but got '" + checkpoint_name +
+                                         "').");
+            }
 
             current_checkpoint++;
             if (current_checkpoint < timers_.size())


### PR DESCRIPTION
# Description
- Report errors from the timing watchdog in `MonitoredRobotDriver` through the `get_error()` method of the driver.
- Implement a `CheckpointTimer` to simplify the timing code in the backend loop.

The `CheckpointTimer` class should not be implemented where it is now.  If you approve the idea in general, I would move it to real_time_tools.

# Do not merge before
- [x] https://github.com/open-dynamic-robot-initiative/mpi_cpp_tools/pull/2
- [x] https://github.com/machines-in-motion/real_time_tools/pull/18