### PR TITLE
Enable usage of multi-process time series in RobotData

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,12 @@ catkin_package(
 add_executable(demo demos/demo.cpp)
 target_link_libraries(demo ${catkin_LIBRARIES})
 
+add_executable(demo_multiprocess_backend demos/demo_multiprocess_backend.cpp)
+target_link_libraries(demo_multiprocess_backend ${catkin_LIBRARIES} rt pthread)
+
+add_executable(demo_multiprocess_frontend demos/demo_multiprocess_frontend.cpp)
+target_link_libraries(demo_multiprocess_frontend ${catkin_LIBRARIES} rt pthread)
+
 #########################
 # manage the unit tests #
 #########################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,14 +35,6 @@ search_for_eigen()
 catkin_python_setup()
 
 
-##set(Boost_USE_STATIC_LIBS OFF)
-##set(Boost_USE_MULTITHREADED ON)
-##set(Boost_USE_STATIC_RUNTIME OFF)
-#find_package(Boost 1.45.0 REQUIRED)
-
-#message(FATAL_ERROR ${Boost_INCLUDE_DIRS})
-
-
 ######################################################
 # define the include directory of all ${CATKIN_PKGS} #
 ######################################################
@@ -50,20 +42,13 @@ include_directories(
     ${PROJECT_SOURCE_DIR}/include
     ${catkin_INCLUDE_DIRS}
     ${Eigen_INCLUDE_DIRS}
-#    ${Boost_INCLUDE_DIRS}
 )
-
-########################################################
-# manage the creation of the libraries and executables #
-########################################################
-add_subdirectory(src)
 
 ##########################################
 # export the package as a catkin package #
 ##########################################
 catkin_package(
   INCLUDE_DIRS include
-  LIBRARIES ${EXPORTED_LIBRAIRIES}
   CATKIN_DEPENDS ${CATKIN_PKGS}
 )
 

--- a/demos/demo.cpp
+++ b/demos/demo.cpp
@@ -148,10 +148,10 @@ int main()
   std::shared_ptr<BaseData> data_ptr = std::make_shared<SingleProcessData>();
 
   // max time allowed for the robot to apply an action.
-  double max_action_duration_s = 0.002;
+  double max_action_duration_s = 0.02;
 
   // max time allowed for 2 successive actions
-  double max_inter_action_duration_s = 0.005;
+  double max_inter_action_duration_s = 0.05;
 
   Backend backend(driver_ptr,
 		  data_ptr,

--- a/demos/demo.cpp
+++ b/demos/demo.cpp
@@ -140,13 +140,12 @@ int main()
 {
 
   typedef robot_interfaces::RobotBackend<Action,Observation> Backend;
-  typedef robot_interfaces::RobotData<Action,
-				      Observation,
-				      robot_interfaces::Status> Data;
+  typedef robot_interfaces::RobotData<Action, Observation> BaseData;
+  typedef robot_interfaces::SingleProcessRobotData<Action, Observation> SingleProcessData;
   typedef robot_interfaces::RobotFrontend<Action,Observation> Frontend;
   
   std::shared_ptr<Driver> driver_ptr = std::make_shared<Driver>();
-  std::shared_ptr<Data> data_ptr = std::make_shared<Data>();
+  std::shared_ptr<BaseData> data_ptr = std::make_shared<SingleProcessData>();
 
   // max time allowed for the robot to apply an action.
   double max_action_duration_s = 0.002;

--- a/demos/demo_multiprocess_backend.cpp
+++ b/demos/demo_multiprocess_backend.cpp
@@ -1,0 +1,127 @@
+/**
+ * @file
+ * @author Vincent Berenz, Felix Widmaier
+ * license License BSD-3-Clause
+ * @copyright Copyright (c) 2019-2020, Max Planck Gesellschaft.
+ *
+ * @brief Minimal demo of robot driver/backend running in its own process
+ */
+
+#include <memory>
+
+#include "robot_interfaces/robot_backend.hpp"
+#include "robot_interfaces/robot_driver.hpp"
+
+#include "types.hpp"
+
+using namespace robot_interfaces::demo;
+
+/**
+ * \example demo_multiprocess_backend.cpp
+ * Robot backend for a dummy "2dof" robot in a multi process setup.
+ */
+
+// TODO put driver in separate file so no duplication to demo.cpp?  Discuss
+// with Vincent.
+
+// Send command to the robot and read observation from the robot
+// The dof positions simply becomes the ones set by the latest action,
+// capped between a min and a max value (0 and 1000)
+class Driver : public robot_interfaces::RobotDriver<Action, Observation>
+{
+public:
+    Driver()
+    {
+    }
+
+    // at init dof are at min value
+    void initialize()
+    {
+        state_[0] = Driver::MIN;
+        state_[1] = Driver::MIN;
+    }
+
+    // just clip desired values
+    // between 0 and 1000
+    Action apply_action(const Action &action_to_apply)
+    {
+        std::cout << "received action ";
+        action_to_apply.print(true);
+
+        Action applied;
+        for (unsigned int i = 0; i < 2; i++)
+        {
+            if (action_to_apply.values[i] > Driver::MAX)
+            {
+                applied.values[i] = Driver::MAX;
+            }
+            else if (action_to_apply.values[i] < Driver::MIN)
+            {
+                applied.values[i] = Driver::MIN;
+            }
+            else
+            {
+                applied.values[i] = action_to_apply.values[i];
+            }
+            // simulating the time if could take for a real
+            // robot to perform the action
+            usleep(1000);
+            state_[i] = applied.values[i];
+        }
+        return applied;
+    }
+
+    Observation get_latest_observation()
+    {
+        Observation observation;
+        observation.values[0] = state_[0];
+        observation.values[1] = state_[1];
+        return observation;
+    }
+
+    std::string get_error()
+    {
+        return "";  // no error
+    }
+
+    void shutdown()
+    {
+        // nothing to do
+    }
+
+private:
+    int state_[2];
+
+    const static int MAX = 1000;
+    const static int MIN = 0;
+};
+
+int main()
+{
+    typedef robot_interfaces::RobotBackend<Action, Observation> Backend;
+    typedef robot_interfaces::MultiProcessRobotData<Action, Observation>
+        MultiProcessData;
+
+    auto driver_ptr = std::make_shared<Driver>();
+    // the backend process acts as master for the shared memory
+    auto data_ptr =
+        std::make_shared<MultiProcessData>("multiprocess_demo", true);
+
+    // max time allowed for the robot to apply an action.
+    double max_action_duration_s = 0.02;
+
+    // max time allowed for 2 successive actions
+    double max_inter_action_duration_s = 0.05;
+
+    Backend backend(driver_ptr,
+                    data_ptr,
+                    max_action_duration_s,
+                    max_inter_action_duration_s);
+    backend.initialize();
+
+    // TODO would be nicer to check if backend loop is still running
+    while (true)
+    {
+    }
+}
+

--- a/demos/demo_multiprocess_frontend.cpp
+++ b/demos/demo_multiprocess_frontend.cpp
@@ -1,0 +1,57 @@
+/**
+ * @file
+ * @author Vincent Berenz, Felix Widmaier
+ * license License BSD-3-Clause
+ * @copyright Copyright (c) 2019-2020, Max Planck Gesellschaft.
+ *
+ * @brief Minimal demo of robot frontend running in its own process
+ */
+
+#include <memory>
+
+#include "robot_interfaces/robot_frontend.hpp"
+
+#include "types.hpp"
+
+using namespace robot_interfaces::demo;
+
+/**
+ * \example demo_multiprocess_frontend.cpp
+ * Robot frontend for a dummy "2dof" robot in a multi process setup.
+ */
+
+int main()
+{
+    typedef robot_interfaces::RobotFrontend<Action, Observation> Frontend;
+    typedef robot_interfaces::MultiProcessRobotData<Action, Observation>
+        MultiProcessData;
+
+    // The shared memory is managed by the backend process, so set the
+    // is_master argument to false.
+    auto data_ptr =
+        std::make_shared<MultiProcessData>("multiprocess_demo", false);
+    Frontend frontend(data_ptr);
+
+    Action action;
+    Observation observation;
+
+    // simulated action :
+    // 1 dof going from 200 to 300
+    // The other going from 300 to 200
+
+    for (uint value = 200; value <= 300; value++)
+    {
+        action.values[0] = value;
+        action.values[1] = 500 - value;
+        // this action will be stored at index
+        robot_interfaces::TimeIndex index =
+            frontend.append_desired_action(action);
+        // getting the observation corresponding to the applied
+        // action, i.e. at the same index
+        observation = frontend.get_observation(index);
+        std::cout << "value: " << value << " | ";
+        action.print(false);
+        observation.print(true);
+    }
+}
+

--- a/demos/types.hpp
+++ b/demos/types.hpp
@@ -1,0 +1,60 @@
+/**
+ * @file
+ * license License BSD-3-Clause
+ * @copyright Copyright (c) 2019-2020, Max Planck Gesellschaft.
+ *
+ * @brief Simple Action and Observation types that are used by some demos.
+ */
+
+#pragma once
+
+namespace robot_interfaces
+{
+namespace demo
+{
+/**
+ * Actions to be performed by robot, will be received by Driver.  An action
+ * simply encapsulate two desired position value, one for each dof
+ */
+class Action
+{
+public:
+    int values[2];
+
+    void print(bool backline) const
+    {
+        std::cout << "action: " << values[0] << " " << values[1] << " ";
+        if (backline) std::cout << "\n";
+    }
+
+    template <class Archive>
+    void serialize(Archive& ar)
+    {
+        ar(values);
+    }
+};
+
+/**
+ * Read from the robot by Driver. An observation is the current position for
+ * each dof.
+ */
+class Observation
+{
+public:
+    int values[2];
+
+    void print(bool backline) const
+    {
+        std::cout << "observation: " << values[0] << " " << values[1] << " ";
+        if (backline) std::cout << "\n";
+    }
+
+    template <class Archive>
+    void serialize(Archive& ar)
+    {
+        ar(values);
+    }
+};
+
+}  // namespace demo
+}  // namespace robot_interfaces

--- a/include/robot_interfaces/cereal_eigen.hpp
+++ b/include/robot_interfaces/cereal_eigen.hpp
@@ -1,0 +1,46 @@
+/**
+ * @file
+ * @brief Serialization functions for serializing Eigen matrices and arrays
+ *        with cereal.
+ * @authors Azoth, eudoxos
+ * @date 2020-01-15
+ * @license CC BY-SA 4.0
+ * @todo Move this to some "serialization tools" package.
+ *
+ * Taken from https://stackoverflow.com/a/51944389/2095383.
+ */
+#include <Eigen/Eigen>
+#include <type_traits>
+
+namespace cereal
+{
+template <class Archive, class Derived>
+inline typename std::enable_if<
+    traits::is_output_serializable<BinaryData<typename Derived::Scalar>,
+                                   Archive>::value,
+    void>::type
+save(Archive& ar, Eigen::PlainObjectBase<Derived> const& m)
+{
+    typedef Eigen::PlainObjectBase<Derived> ArrT;
+    if (ArrT::RowsAtCompileTime == Eigen::Dynamic) ar(m.rows());
+    if (ArrT::ColsAtCompileTime == Eigen::Dynamic) ar(m.cols());
+    ar(binary_data(m.data(), m.size() * sizeof(typename Derived::Scalar)));
+}
+
+template <class Archive, class Derived>
+inline typename std::enable_if<
+    traits::is_input_serializable<BinaryData<typename Derived::Scalar>,
+                                  Archive>::value,
+    void>::type
+load(Archive& ar, Eigen::PlainObjectBase<Derived>& m)
+{
+    typedef Eigen::PlainObjectBase<Derived> ArrT;
+    Eigen::Index rows = ArrT::RowsAtCompileTime, cols = ArrT::ColsAtCompileTime;
+    if (rows == Eigen::Dynamic) ar(rows);
+    if (cols == Eigen::Dynamic) ar(cols);
+    m.resize(rows, cols);
+    ar(binary_data(m.data(),
+                   static_cast<std::size_t>(rows * cols *
+                                            sizeof(typename Derived::Scalar))));
+}
+}  // namespace cereal

--- a/include/robot_interfaces/n_joint_robot_types.hpp
+++ b/include/robot_interfaces/n_joint_robot_types.hpp
@@ -16,35 +16,9 @@
 #include <robot_interfaces/robot_backend.hpp>
 #include <robot_interfaces/robot_data.hpp>
 #include <robot_interfaces/robot_frontend.hpp>
-
 #include <robot_interfaces/robot_logger.hpp>
+#include <robot_interfaces/cereal_eigen.hpp>
 
-// https://stackoverflow.com/a/51944389/2095383
-// Authors: Azoth, eudoxos
-// Date: 2020-01-15
-// License: CC BY-SA 4.0
-namespace cereal
-{
-  template <class Archive, class Derived> inline
-    typename std::enable_if<traits::is_output_serializable<BinaryData<typename Derived::Scalar>, Archive>::value, void>::type
-    save(Archive & ar, Eigen::PlainObjectBase<Derived> const & m){
-      typedef Eigen::PlainObjectBase<Derived> ArrT;
-      if(ArrT::RowsAtCompileTime==Eigen::Dynamic) ar(m.rows());
-      if(ArrT::ColsAtCompileTime==Eigen::Dynamic) ar(m.cols());
-      ar(binary_data(m.data(),m.size()*sizeof(typename Derived::Scalar)));
-    }
-
-  template <class Archive, class Derived> inline
-    typename std::enable_if<traits::is_input_serializable<BinaryData<typename Derived::Scalar>, Archive>::value, void>::type
-    load(Archive & ar, Eigen::PlainObjectBase<Derived> & m){
-      typedef Eigen::PlainObjectBase<Derived> ArrT;
-      Eigen::Index rows=ArrT::RowsAtCompileTime, cols=ArrT::ColsAtCompileTime;
-      if(rows==Eigen::Dynamic) ar(rows);
-      if(cols==Eigen::Dynamic) ar(cols);
-      m.resize(rows,cols);
-      ar(binary_data(m.data(),static_cast<std::size_t>(rows*cols*sizeof(typename Derived::Scalar))));
-    }
-}
 
 namespace robot_interfaces
 {

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -50,7 +50,7 @@ public:
      */
     RobotBackend(
         std::shared_ptr<RobotDriver<Action, Observation>> robot_driver,
-        std::shared_ptr<RobotData<Action, Observation, Status>> robot_data,
+        std::shared_ptr<RobotData<Action, Observation>> robot_data,
         const double max_action_duration_s,
         const double max_inter_action_duration_s)
         : robot_driver_(
@@ -100,7 +100,7 @@ public:
 
 private:
     MonitoredRobotDriver<Action, Observation> robot_driver_;
-    std::shared_ptr<RobotData<Action, Observation, Status>> robot_data_;
+    std::shared_ptr<RobotData<Action, Observation>> robot_data_;
     std::atomic<bool> destructor_was_called_;
 
     /**

--- a/include/robot_interfaces/robot_data.hpp
+++ b/include/robot_interfaces/robot_data.hpp
@@ -1,10 +1,11 @@
-///////////////////////////////////////////////////////////////////////////////
-// BSD 3-Clause License
-//
-// Copyright (C) 2018-2019, Max Planck Gesellschaft
-// Copyright note valid unless otherwise stated in individual files.
-// All rights reserved.
-///////////////////////////////////////////////////////////////////////////////
+/**
+ * @file
+ * @license BSD 3-clause
+ * @copyright Copyright (c) 2018-2020, New York University and Max Planck
+ *            Gesellschaft
+ *
+ * @brief RobotData classes for both single- and multi-process applications.
+ */
 
 #pragma once
 
@@ -12,82 +13,159 @@
 #include <memory>
 #include <string>
 
+#include <time_series/multiprocess_time_series.hpp>
 #include <time_series/time_series.hpp>
+
+#include "status.hpp"
 
 namespace robot_interfaces
 {
-template <typename Type>
-using Timeseries = time_series::TimeSeries<Type>;
-
 /**
  * @brief Contains all the input and output data of the robot.
  *
  * This means the
- * - desired_action which was requested by the robot user
- * - applied_action which was actually applied and may not be
+ * - `desired_action` which was requested by the robot user
+ * - `applied_action` which was actually applied and may not be
  *                  and may not be identical to desired_action
  *                  for safety reasons
- * - observation made by the robot
- * - status which keeps track of some timing issues (may still change).
+ * - `observation` made by the robot
+ * - `status` which keeps track of timing issues and errors.
  *
  * See this graph to understand how they relate to each other precisely
  * in terms of time:
  *
- * |------ t = 0 ------|------ t = 1 ------|
- * |----- action0 -----|----- action1 -----|
- * o                   o                   o
- * b                   b                   b
- * s                   s                   s
- * 0                   1                   2
+ * @verbatim
+   |------ t = 0 ------|------ t = 1 ------|
+   |----- action0 -----|----- action1 -----|
+   o                   o                   o
+   b                   b                   b
+   s                   s                   s
+   0                   1                   2
+   @endverbatim
  *
- *
- * @tparam Action
- * @tparam Observation
- * @tparam Status
+ * @tparam Action Type of the actions.
+ * @tparam Observation Type of the observations.
  */
-
-template <typename Action, typename Observation, typename Status>
+template <typename Action, typename Observation>
 class RobotData
 {
 public:
-    template <typename Type>
-    using Ptr = std::shared_ptr<Type>;
+    //! @brief Time series of the desired actions.
+    std::shared_ptr<time_series::TimeSeriesInterface<Action>> desired_action;
+    //! @brief Time series of the actually applied actions (due to safety
+    //         checks).
+    std::shared_ptr<time_series::TimeSeriesInterface<Action>> applied_action;
+    //! @brief Time series of the observations retrieved from the robot.
+    std::shared_ptr<time_series::TimeSeriesInterface<Observation>> observation;
+    //! @brief Time series of status messages.
+    std::shared_ptr<time_series::TimeSeriesInterface<Status>> status;
 
-    RobotData(size_t history_length = 1000,
-              bool use_shared_memory = false,
-              // suppress unused warning (will be used in the future)
-              __attribute__((unused)) std::string shared_memory_address = "")
-    {
-        if (use_shared_memory)
-        {
-            std::cout << "shared memory robot data is not implemented yet"
-                      << std::endl;
-            exit(-1);
+protected:
+    // make constructor protected to prevent instantiation of the base class
+    RobotData(){};
+};
 
-            // TODO: here we should check if the shared memory at that
-            // address already exists, otherwise we create it.
-            // we will also have to update timeseries such as to handle
-            // serialization internally (it will simply assume that the
-            // templated class has a method called serialize() and
-            // from_serialized())
-        }
-        else
-        {
-            desired_action =
-                std::make_shared<Timeseries<Action>>(history_length);
-            applied_action =
-                std::make_shared<Timeseries<Action>>(history_length);
-            observation =
-                std::make_shared<Timeseries<Observation>>(history_length);
-            status = std::make_shared<Timeseries<Status>>(history_length);
-        }
-    }
-
+/**
+ * @brief RobotData instance using single process time series.
+ *
+ * Use this class if all modules accessing the data are running in the same
+ * process.  If modules run in separate processes, use MultiProcessRobotData
+ * instead.
+ *
+ * @copydoc RobotData
+ * @see MultiProcessRobotData
+ */
+template <typename Action, typename Observation>
+class SingleProcessRobotData : public RobotData<Action, Observation>
+{
 public:
-    Ptr<Timeseries<Action>> desired_action;
-    Ptr<Timeseries<Action>> applied_action;
-    Ptr<Timeseries<Observation>> observation;
-    Ptr<Timeseries<Status>> status;
+    /**
+     * @brief Construct the time series for the robot data.
+     *
+     * @param history_length History length of the time series.
+     */
+    SingleProcessRobotData(size_t history_length = 1000)
+    {
+        std::cout << "Using single process time series." << std::endl;
+        this->desired_action =
+            std::make_shared<time_series::TimeSeries<Action>>(history_length);
+        this->applied_action =
+            std::make_shared<time_series::TimeSeries<Action>>(history_length);
+        this->observation =
+            std::make_shared<time_series::TimeSeries<Observation>>(
+                history_length);
+        this->status =
+            std::make_shared<time_series::TimeSeries<Status>>(history_length);
+    }
+};
+
+/**
+ * @brief RobotData instance using multi process time series.
+ *
+ * Use this class if modules accessing the data are running in separate
+ * processes.  When all modules run as threads in the same process, this class
+ * can be used as well, however, SingleProcessRobotData might be more efficient
+ * in that case.
+ *
+ * @copydoc RobotData
+ * @see SingleProcessRobotData
+ */
+template <typename Action, typename Observation>
+class MultiProcessRobotData : public RobotData<Action, Observation>
+{
+public:
+    /**
+     * @brief Construct the time series for the robot data.
+     *
+     * @param shared_memory_id_prefix Prefix for the shared memory IDs.  Since
+     *     each time series needs its own memory ID, the given value is used as
+     *     prefix and unique suffixes are appended.  Make sure to use a prefix
+     *     that cannot lead to name collisions on your system.
+     * @param is_master If set to true, this instance will clear the shared
+     *     memory on construction and destruction.  Only once instance should
+     *     act as master in a multi-process setup.
+     * @param history_length History length of the time series.
+     */
+    MultiProcessRobotData(const std::string &shared_memory_id_prefix,
+                          bool is_master,
+                          size_t history_length = 1000)
+    {
+        std::cout << "Using multi process time series." << std::endl;
+
+        // each time series needs its own shared memory ID, so add unique
+        // suffixes to the given ID.
+        const std::string id_desired_action =
+            shared_memory_id_prefix + "_desired_action";
+        const std::string id_applied_action =
+            shared_memory_id_prefix + "_applied_action";
+        const std::string id_observation =
+            shared_memory_id_prefix + "_observation";
+        const std::string id_status = shared_memory_id_prefix + "_status";
+
+        if (is_master)
+        {
+            // the master instance is in charge of cleaning the memory
+            time_series::clear_memory(id_desired_action);
+            time_series::clear_memory(id_applied_action);
+            time_series::clear_memory(id_observation);
+            time_series::clear_memory(id_status);
+        }
+
+        const bool clean_on_destruction = is_master;
+
+        this->desired_action =
+            std::make_shared<time_series::MultiprocessTimeSeries<Action>>(
+                id_desired_action, history_length, clean_on_destruction);
+        this->applied_action =
+            std::make_shared<time_series::MultiprocessTimeSeries<Action>>(
+                id_applied_action, history_length, clean_on_destruction);
+        this->observation =
+            std::make_shared<time_series::MultiprocessTimeSeries<Observation>>(
+                id_observation, history_length, clean_on_destruction);
+        this->status =
+            std::make_shared<time_series::MultiprocessTimeSeries<Status>>(
+                id_status, history_length, clean_on_destruction);
+    }
 };
 
 }  // namespace robot_interfaces

--- a/include/robot_interfaces/robot_frontend.hpp
+++ b/include/robot_interfaces/robot_frontend.hpp
@@ -15,6 +15,7 @@
 
 #include <robot_interfaces/robot_backend.hpp>
 #include <robot_interfaces/robot_data.hpp>
+#include <robot_interfaces/status.hpp>
 
 namespace robot_interfaces
 {
@@ -40,7 +41,7 @@ public:
     typedef time_series::Timestamp TimeStamp;
 
     RobotFrontend(
-        std::shared_ptr<RobotData<Action, Observation, Status>> robot_data)
+        std::shared_ptr<RobotData<Action, Observation>> robot_data)
         : robot_data_(robot_data)
     {
     }
@@ -120,7 +121,7 @@ public:
     }
 
 private:
-    std::shared_ptr<RobotData<Action, Observation, Status>> robot_data_;
+    std::shared_ptr<RobotData<Action, Observation>> robot_data_;
 };
 
 }  // namespace robot_interfaces

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -24,6 +24,7 @@
 #include <real_time_tools/timer.hpp>
 
 #include <robot_interfaces/loggable.hpp>
+#include <robot_interfaces/status.hpp>
 
 namespace robot_interfaces
 {
@@ -37,9 +38,8 @@ namespace robot_interfaces
  *
  * @tparam Action
  * @tparam Observation
- * @tparam Status
  */
-template <typename Action, typename Observation, typename Status>
+template <typename Action, typename Observation>
 class RobotLogger
 {
 public:
@@ -59,7 +59,7 @@ public:
      * is to be logged- applied_action and desired_action (of type Action),
      * observation (of type Observation), and status (of type Status).
      */
-    std::shared_ptr<robot_interfaces::RobotData<Action, Observation, Status>>
+    std::shared_ptr<robot_interfaces::RobotData<Action, Observation>>
         logger_data_;
 
     int block_size_;
@@ -71,7 +71,7 @@ public:
     std::string output_file_name_;
 
     RobotLogger(std::shared_ptr<
-                    robot_interfaces::RobotData<Action, Observation, Status>>
+                    robot_interfaces::RobotData<Action, Observation>>
                     robot_data,
                 int block_size)
         : logger_data_(robot_data),

--- a/include/robot_interfaces/status.hpp
+++ b/include/robot_interfaces/status.hpp
@@ -13,6 +13,8 @@
 
 #pragma once
 
+#include <cereal/types/string.hpp>
+
 #include <robot_interfaces/loggable.hpp>
 #include <string>
 #include <vector>
@@ -49,6 +51,12 @@ struct Status : public Loggable
      * Value is undefined if `error_status == NO_ERROR`.
      */
     std::string error_message;
+
+    template <class Archive>
+    void serialize(Archive& archive)
+    {
+        archive(action_repetitions, error_status, error_message);
+    }
 
     std::vector<std::string> get_name() override
     {

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,0 @@
-######################################################
-# Export the libraries in the devel folder of catkin #
-######################################################
-
-set(EXPORTED_LIBRAIRIES ${EXPORTED_LIBRAIRIES} ${LIBRARIES_TO_BE_EXPORTED}
-    PARENT_SCOPE)


### PR DESCRIPTION
# Summary
- Split RobotData into a single-process and multi-process version.
- Add a C++ demo for multiprocessing.

# Detailed
The `RobotData` class remains as base class, holding the pointers to the
time series, but does not initialize them.  Initialization is done in
the derived classes `SingleProcessRobotData` (using the single process
time series) and `MultiProcessRobotData` (using the multi process time
series).

This split is needed because the originally intended design with a
if-check does not compile with template types that are not serializable,
even when only single process is used.

While doing this, also remove the `Status` argument from the templates
(the type for this is fixed anyway).

Add a multiprocess demo. It is based on demo.cpp but split into separate executables for
backend and frontend, using the `MultiProcessRobotData` for communication.

Also do some cleanup in the CMakeLists.txt.

# How I Tested
By running the demos of this package as well as the `demo_fake_finger.py` of blmc_robots (adapt the latter to work with single- and multi-process versions of robot data).

# Do not merge before
- [x] https://github.com/open-dynamic-robot-initiative/blmc_robots/pull/50 is ready.
- [ ] ~corresponding merge request on blmc_robots_ros~