### PR TITLE
Fix PD controller

### DIFF
--- a/include/robot_interfaces/n_joint_robot_functions.hpp
+++ b/include/robot_interfaces/n_joint_robot_functions.hpp
@@ -97,7 +97,7 @@ struct NJointRobotFunctions
 
             // simple PD controller
             typename Types::Vector position_control_torque =
-                processed_action.position_kp.cwiseProduct(position_error) +
+                processed_action.position_kp.cwiseProduct(position_error) -
                 processed_action.position_kd.cwiseProduct(
                     latest_observation.velocity);
 


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
@shrutij01 pointed out a mistake in the PD controller: The P and D parts where added but when using the velocity in the D part, it should actually be subtracted. I.e. it should be `kp * p_err - kd * vel`.

## How I Tested
With the Finger robot, increasing the D gain.  With the old code, the robot started to move around.  With the fix it vibrates but stays at the desired position (which is the expected behaviour).


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
