### PR TITLE
Fix Unit Test for Position Controller

### DIFF
--- a/tests/test_process_action.cpp
+++ b/tests/test_process_action.cpp
@@ -252,10 +252,11 @@ TEST_F(TestProcessDesiredAction, position_controller_with_velocity)
             default_position_control_kd);
 
     // Since velocity has same sign as position error, the resulting
-    // (absolute) torques should be higher
-    EXPECT_GT(result_action_without_velocity.torque[0],
+    // (absolute) torques should be lower (since it is
+    //   torque = P * position_error - D * velocity )
+    EXPECT_LT(result_action_without_velocity.torque[0],
               result_action_with_velocity.torque[0]);
-    EXPECT_LT(result_action_without_velocity.torque[1],
+    EXPECT_GT(result_action_without_velocity.torque[1],
               result_action_with_velocity.torque[1]);
 }
 


### PR DESCRIPTION
## Description

In 76c5373 a bug in the position PD controller was fixed (replacing `+`
with `-`).  Since this was a conceptual mistake rather than a typo, the
corresponding unit test was also checking for the wrong result.  This
commit fixes this.


## How I Tested

By running the unit tests.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
