### PR TITLE
Release GIL when calling C++ methods, terminate backend cleanly & add real-time mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,19 +58,26 @@ include_directories(
 catkin_package(
   INCLUDE_DIRS include
   CATKIN_DEPENDS ${CATKIN_PKGS}
+  LIBRARIES global_signal_handler
 )
+
+
+add_library(global_signal_handler src/global_signal_handler.cpp)
+target_link_libraries(global_signal_handler ${catkin_LIBRARIES})
 
 ####################
 # manage the demos #
 ####################
 add_executable(demo demos/demo.cpp)
-target_link_libraries(demo ${catkin_LIBRARIES})
+target_link_libraries(demo ${catkin_LIBRARIES} global_signal_handler)
 
 add_executable(demo_multiprocess_backend demos/demo_multiprocess_backend.cpp)
-target_link_libraries(demo_multiprocess_backend ${catkin_LIBRARIES} rt pthread)
+target_link_libraries(demo_multiprocess_backend ${catkin_LIBRARIES}
+    global_signal_handler rt pthread)
 
 add_executable(demo_multiprocess_frontend demos/demo_multiprocess_frontend.cpp)
-target_link_libraries(demo_multiprocess_frontend ${catkin_LIBRARIES} rt pthread)
+target_link_libraries(demo_multiprocess_frontend ${catkin_LIBRARIES}
+    global_signal_handler rt pthread)
 
 #########################
 # manage the unit tests #
@@ -81,62 +88,21 @@ add_subdirectory(tests)
 # python bindings #
 ###################
 
-# generic #
-pybind11_add_module(py_generic srcpy/py_generic.cpp)
-target_link_libraries(py_generic PRIVATE ${catkin_LIBRARIES})
-set_target_properties(py_generic PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
-install(TARGETS py_generic DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
+macro(add_python_bindings module_name)
+    pybind11_add_module(${module_name} srcpy/${module_name}.cpp)
+    target_link_libraries(${module_name} PRIVATE
+        ${catkin_LIBRARIES} global_signal_handler ${ARGN})
+    set_target_properties(${module_name} PROPERTIES
+        LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
+    install(TARGETS ${module_name} DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
+endmacro()
 
-# camera #
-set(py_camera_types_SRC_FILES
-  srcpy/py_camera_types.cpp
-)
-pybind11_add_module(py_camera_types ${py_camera_types_SRC_FILES})
-target_link_libraries(py_camera_types PRIVATE ${catkin_LIBRARIES} ${OpenCV_LIBRARIES} ${Pylon_LIBRARIES})
-set_target_properties(py_camera_types PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
-install(TARGETS py_camera_types DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
-
-# finger #
-set(py_finger_types_SRC_FILES
-  srcpy/py_finger_types.cpp
-)
-pybind11_add_module(py_finger_types ${py_finger_types_SRC_FILES})
-target_link_libraries(py_finger_types PRIVATE ${catkin_LIBRARIES})
-set_target_properties(py_finger_types PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
-install(TARGETS py_finger_types DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
-
-# trifinger #
-set(py_trifinger_types_SRC_FILES
-  srcpy/py_trifinger_types.cpp
-)
-pybind11_add_module(py_trifinger_types ${py_trifinger_types_SRC_FILES})
-target_link_libraries(py_trifinger_types PRIVATE ${catkin_LIBRARIES})
-set_target_properties(py_trifinger_types PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
-install(TARGETS py_trifinger_types DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
-
-# one joint #
-set(py_one_joint_types_SRC_FILES
-  srcpy/py_one_joint_types.cpp
-)
-pybind11_add_module(py_one_joint_types ${py_one_joint_types_SRC_FILES})
-target_link_libraries(py_one_joint_types PRIVATE ${catkin_LIBRARIES})
-set_target_properties(py_one_joint_types PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
-install(TARGETS py_one_joint_types DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
-
-# two joint #
-set(py_two_joint_types_SRC_FILES
-  srcpy/py_two_joint_types.cpp
-)
-pybind11_add_module(py_two_joint_types ${py_two_joint_types_SRC_FILES})
-target_link_libraries(py_two_joint_types PRIVATE ${catkin_LIBRARIES})
-set_target_properties(py_two_joint_types PROPERTIES
-    LIBRARY_OUTPUT_DIRECTORY ${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_PYTHON_DESTINATION})
-install(TARGETS py_two_joint_types DESTINATION ${CATKIN_PACKAGE_PYTHON_DESTINATION})
+add_python_bindings(py_generic)
+add_python_bindings(py_camera_types ${OpenCV_LIBRARIES} ${Pylon_LIBRARIES})
+add_python_bindings(py_finger_types)
+add_python_bindings(py_trifinger_types)
+add_python_bindings(py_one_joint_types)
+add_python_bindings(py_two_joint_types)
 
 
 ##########################

--- a/include/robot_interfaces/global_signal_handler.hpp
+++ b/include/robot_interfaces/global_signal_handler.hpp
@@ -1,0 +1,49 @@
+/**
+ * @file
+ * @copyright 2020, New York University, Max Planck Gesellschaft. All rights
+ *            reserved.
+ * @license BSD 3-clause
+ */
+#pragma once
+
+namespace robot_interfaces
+{
+/**
+ * @brief Static class implementing a signal handler and providing information
+ *        about SIGINT.
+ *
+ * Since signal handlers cannot be implemented in a non-static class method, use
+ * this globally accessible class as a workaround.  It registers a signal
+ * handler provides static methods to poll if certain signals are received.
+ */
+class GlobalSignalHandler
+{
+public:
+    /**
+     * @brief Initialize the signal handler.
+     *
+     * This must be called before using the class.  Does nothing when called a
+     * second time.
+     */
+    static void initialize();
+
+    //! @brief Handles the signals.  Do not call this directly.
+    static void signal_handler(int signal);
+
+    /**
+     * @brief Check if a SIGINT was received.
+     *
+     * @return True if SIGINT was received.
+     */
+    static bool has_received_sigint();
+
+private:
+    GlobalSignalHandler()
+    {
+        // private constructor to prevent instantiation
+    }
+
+    static bool received_sigint_;
+};
+
+}  // namespace robot_interfaces

--- a/include/robot_interfaces/monitored_robot_driver.hpp
+++ b/include/robot_interfaces/monitored_robot_driver.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <cmath>
 #include <iostream>
 
 #include <real_time_tools/process_manager.hpp>
@@ -69,7 +70,14 @@ public:
           action_end_logger_(1000)
     {
         thread_ = std::make_shared<real_time_tools::RealTimeThread>();
-        thread_->create_realtime_thread(&MonitoredRobotDriver::loop, this);
+
+        // if both timeouts are infinite, there is no need to start the loop at
+        // all
+        if (!std::isinf(max_action_duration_s_) ||
+            !std::isinf(max_inter_action_duration_s_))
+        {
+            thread_->create_realtime_thread(&MonitoredRobotDriver::loop, this);
+        }
     }
 
     /**
@@ -189,7 +197,8 @@ private:
                                                       max_action_duration_s_);
             if (!action_has_ended_on_time)
             {
-                error_message_.set("Action did not end on time, shutting down.");
+                error_message_.set(
+                    "Action did not end on time, shutting down.");
                 shutdown();
                 return;
             }
@@ -199,7 +208,8 @@ private:
                     t + 1, max_inter_action_duration_s_);
             if (!action_has_started_on_time)
             {
-                error_message_.set("Action did not start on time, shutting down.");
+                error_message_.set(
+                    "Action did not start on time, shutting down.");
                 shutdown();
                 return;
             }

--- a/include/robot_interfaces/monitored_robot_driver.hpp
+++ b/include/robot_interfaces/monitored_robot_driver.hpp
@@ -89,11 +89,6 @@ public:
         thread_->join();
     }
 
-    double get_max_inter_action_duration_s()
-    {
-        return max_inter_action_duration_s_;
-    }
-
     /**
      * @brief Apply desired action on the robot.
      *

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -60,7 +60,12 @@ void create_python_bindings(pybind11::module &m)
 
     pybind11::class_<typename Types::Backend, typename Types::BackendPtr>(
         m, "Backend")
-        .def("initialize", &Types::Backend::initialize);
+        .def("initialize",
+             &Types::Backend::initialize,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("wait_until_terminated",
+             &Types::Backend::wait_until_terminated,
+             pybind11::call_guard<pybind11::gil_scoped_release>());
 
     pybind11::class_<typename Types::Action>(m, "Action")
         .def_readwrite("torque", &Types::Action::torque)
@@ -82,6 +87,9 @@ void create_python_bindings(pybind11::module &m)
         .def_readwrite("velocity", &Types::Observation::velocity)
         .def_readwrite("torque", &Types::Observation::torque);
 
+    // Release the GIL when calling any of the front-end functions, so in case
+    // there are subthreads running Python, they have a chance to acquire the
+    // GIL.
     pybind11::class_<typename Types::Frontend, typename Types::FrontendPtr>(
         m, "Frontend")
         .def(pybind11::init<typename Types::BaseDataPtr>())

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -85,14 +85,30 @@ void create_python_bindings(pybind11::module &m)
     pybind11::class_<typename Types::Frontend, typename Types::FrontendPtr>(
         m, "Frontend")
         .def(pybind11::init<typename Types::BaseDataPtr>())
-        .def("get_observation", &Types::Frontend::get_observation)
-        .def("get_desired_action", &Types::Frontend::get_desired_action)
-        .def("get_applied_action", &Types::Frontend::get_applied_action)
-        .def("get_status", &Types::Frontend::get_status)
-        .def("get_time_stamp_ms", &Types::Frontend::get_time_stamp_ms)
-        .def("append_desired_action", &Types::Frontend::append_desired_action)
-        .def("wait_until_time_index", &Types::Frontend::wait_until_timeindex)
-        .def("get_current_time_index", &Types::Frontend::get_current_timeindex);
+        .def("get_observation",
+             &Types::Frontend::get_observation,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_desired_action",
+             &Types::Frontend::get_desired_action,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_applied_action",
+             &Types::Frontend::get_applied_action,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_status",
+             &Types::Frontend::get_status,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_time_stamp_ms",
+             &Types::Frontend::get_time_stamp_ms,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("append_desired_action",
+             &Types::Frontend::append_desired_action,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("wait_until_time_index",
+             &Types::Frontend::wait_until_timeindex,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_current_time_index",
+             &Types::Frontend::get_current_timeindex,
+             pybind11::call_guard<pybind11::gil_scoped_release>());
 
     pybind11::class_<typename Types::Logger>(m, "Logger")
         .def(pybind11::init<typename Types::BaseDataPtr, int>())

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -222,7 +222,6 @@ private:
             {
                 std::cerr << "Error: " << status.error_message
                           << "\nRobot is shut down." << std::endl;
-                robot_driver_.shutdown();
                 break;
             }
             timer_.checkpoint("status");
@@ -234,7 +233,6 @@ private:
             }
             if (has_shutdown_request())
             {
-                // TODO should shut down robot?
                 break;
             }
 
@@ -253,6 +251,7 @@ private:
             }
         }
 
+        robot_driver_.shutdown();
         loop_is_running_ = false;
     }
 };

--- a/src/global_signal_handler.cpp
+++ b/src/global_signal_handler.cpp
@@ -1,0 +1,39 @@
+/**
+ * @file
+ * @copyright 2020, New York University, Max Planck Gesellschaft. All rights
+ *            reserved.
+ * @license BSD 3-clause
+ */
+#include <csignal>
+#include <robot_interfaces/global_signal_handler.hpp>
+
+namespace robot_interfaces
+{
+bool GlobalSignalHandler::received_sigint_ = false;
+
+void GlobalSignalHandler::initialize()
+{
+    static bool is_initialized = false;
+
+    if (!is_initialized)
+    {
+        std::signal(SIGINT, &GlobalSignalHandler::signal_handler);
+        received_sigint_ = false;
+        is_initialized = true;
+    }
+}
+
+void GlobalSignalHandler::signal_handler(int signal)
+{
+    if (signal == SIGINT)
+    {
+        received_sigint_ = true;
+    }
+}
+
+bool GlobalSignalHandler::has_received_sigint()
+{
+    return received_sigint_;
+}
+
+}  // namespace robot_interfaces


### PR DESCRIPTION
## Description

By releasing the GIL while calling the (C++) frontend methods, other
threads can acquire it if needed.

This is, for example, needed for the pyBullet Driver where the backend
loop needs to call Python functions and needs the GIL for that.

## How I Tested
By running the pipeline with the pyBullet driver (to be provided in another PR).
Not tested with real robot due to current lack of access.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
