### PR TITLE
Changing to a non-realtime thread in the sensor backend

### DIFF
--- a/include/robot_interfaces/sensors/sensor_backend.hpp
+++ b/include/robot_interfaces/sensors/sensor_backend.hpp
@@ -11,6 +11,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <thread>
 
 #include <real_time_tools/process_manager.hpp>
 #include <real_time_tools/thread.hpp>
@@ -45,14 +46,13 @@ public:
           sensor_data_(sensor_data),
           destructor_was_called_(false)
     {
-        thread_ = std::make_shared<real_time_tools::RealTimeThread>();
-        thread_->create_realtime_thread(&SensorBackend::loop, this);
+        thread_ = std::thread(&SensorBackend<ObservationType>::loop, this);
     }
 
     virtual ~SensorBackend()
     {
         destructor_was_called_ = true;
-        thread_->join();
+        thread_.join();
     }
 
 private:
@@ -61,13 +61,7 @@ private:
 
     bool destructor_was_called_;
 
-    std::shared_ptr<real_time_tools::RealTimeThread> thread_;
-
-    static void *loop(void *instance_pointer)
-    {
-        ((SensorBackend *)(instance_pointer))->loop();
-        return nullptr;
-    }
+    std::thread thread_;
 
     /**
      * @brief Main loop.

--- a/include/robot_interfaces/sensors/sensor_backend.hpp
+++ b/include/robot_interfaces/sensors/sensor_backend.hpp
@@ -13,10 +13,6 @@
 #include <cstdint>
 #include <thread>
 
-#include <real_time_tools/process_manager.hpp>
-#include <real_time_tools/thread.hpp>
-#include <real_time_tools/timer.hpp>
-
 #include <robot_interfaces/sensors/opencv_driver.hpp>
 #include <robot_interfaces/sensors/sensor_data.hpp>
 #include <robot_interfaces/sensors/sensor_driver.hpp>


### PR DESCRIPTION
## Description

Earlier, the sensor backend was creating a realtime thread for the loop getting observations through the sensor driver and appending these to the sensor data. But as this anyway does not run in realtime, a non-realtime thread is used now. 

This fixes #40.

## How I Tested

Through the demo_camera

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
