### PR TITLE
Removed a print statement from the PylonDriver

### DIFF
--- a/include/robot_interfaces/sensors/pylon_driver.hpp
+++ b/include/robot_interfaces/sensors/pylon_driver.hpp
@@ -46,7 +46,6 @@ public:
         Pylon::CTlFactory& tl_factory = Pylon::CTlFactory::GetInstance();
         Pylon::PylonInitialize();
         Pylon::DeviceInfoList_t device_list;
-        std::cout << tl_factory.EnumerateDevices(device_list) << std::endl;
 
         if (tl_factory.EnumerateDevices(device_list) == 0)
         {


### PR DESCRIPTION
## Description

Sorry for the inconvenience, had missed this one line that was printing the number of devices found. Removed that.


## How I Tested

Everything still works through the demo_camera.

## I fulfilled the following requirements
- [ x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [ x] All new functions/classes are documented and existing documentation is updated according to changes.
- [ x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
