### PR TITLE
Use more explicit column names in log file

### DIFF
--- a/include/robot_interfaces/n_joint_robot_types.hpp
+++ b/include/robot_interfaces/n_joint_robot_types.hpp
@@ -57,7 +57,7 @@ struct NJointRobotTypes
 
         std::vector<std::string> get_name() override
         {
-            return {"Torque", "Position", "Position_kp", "Position_kd"};
+            return {"torque", "position", "position_kp", "position_kd"};
         }
 
         std::vector<std::vector<double>> get_data() override
@@ -217,7 +217,7 @@ struct NJointRobotTypes
 
         std::vector<std::string> get_name() override
         {
-            return {"Position", "Velocity", "Torque"};
+            return {"position", "velocity", "torque"};
         }
 
         std::vector<std::vector<double>> get_data() override

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -70,10 +70,10 @@ public:
     std::ofstream output_file_;
     std::string output_file_name_;
 
-    RobotLogger(std::shared_ptr<
-                    robot_interfaces::RobotData<Action, Observation>>
-                    robot_data,
-                int block_size)
+    RobotLogger(
+        std::shared_ptr<robot_interfaces::RobotData<Action, Observation>>
+            robot_data,
+        int block_size)
         : logger_data_(robot_data),
           block_size_(block_size),
           stop_was_called_(false)
@@ -212,7 +212,8 @@ public:
                     desired_action.get_data();
 
                 output_file_ << j << " "
-                    << logger_data_->observation->timestamp_s(j) << " ";
+                             << logger_data_->observation->timestamp_s(j)
+                             << " ";
 
                 append_field_data_to_file(status_data);
                 append_field_data_to_file(observation_data);
@@ -311,13 +312,15 @@ public:
     }
 
     /**
-     * @brief Call start() to create the thread for the RobotLogger and start logging!
+     * @brief Call start() to create the thread for the RobotLogger and start
+     * logging!
      *
      * \note
-     * Every time you start the logger with the same file name, it will obviously
-     * append newer data to the same file. This shouldn't be a problem. But for
-     * different log files, specify different file names while starting the logger.
-     * 
+     * Every time you start the logger with the same file name, it will
+     * obviously append newer data to the same file. This shouldn't be a
+     * problem. But for different log files, specify different file names while
+     * starting the logger.
+     *
      * @param filename The name of the log file.
      */
     void start(std::string filename)

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -116,17 +116,16 @@ public:
 
         std::vector<std::string> header;
 
-        header.push_back("#");
-        header.push_back("[Timestamp]");
-        header.push_back("Time_Index");
+        header.push_back("#time_index");
+        header.push_back("timestamp");
 
-        append_name_to_header("(S)", status_name, status_data, header);
+        append_name_to_header("status", status_name, status_data, header);
         append_name_to_header(
-            "(O)", observation_name, observation_data, header);
+            "observation", observation_name, observation_data, header);
         append_name_to_header(
-            "(AA)", applied_action_name, applied_action_data, header);
+            "applied_action", applied_action_name, applied_action_data, header);
         append_name_to_header(
-            "(DA)", desired_action_name, desired_action_data, header);
+            "desired_action", desired_action_name, desired_action_data, header);
 
         return header;
     }
@@ -212,8 +211,8 @@ public:
                 std::vector<std::vector<double>> desired_action_data =
                     desired_action.get_data();
 
-                output_file_ << logger_data_->observation->timestamp_s(j) << " "
-                             << j << " ";
+                output_file_ << j << " "
+                    << logger_data_->observation->timestamp_s(j) << " ";
 
                 append_field_data_to_file(status_data);
                 append_field_data_to_file(observation_data);


### PR DESCRIPTION
## Description

- Change the order of time index and time stamp in the logfile.  Now
  time index is the first column.
- Use more explicit prefixes for the column names (e.g. "applied_action"
  instead of "(AA)").
- Change column names to lower case everywhere.
- Remove the space between the `#` and the first column name.  This way,
  the first line can be interpreted as header (with first column
  "#time_index"), while it can also still be interpreted as comment by
  tools that don't support the header.

## How I Tested
With `robot_fingers/demo_data_logging.py`.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
