### PR TITLE
RobotBackend: Add "First Action"-Timeout

### DIFF
--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -219,7 +219,7 @@ private:
                 std::cerr << "Error: " << status.error_message
                           << "\nRobot is shut down." << std::endl;
 
-                this->request_shutdown();
+                request_shutdown();
                 break;
             }
         }


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
Add a timeout to `RobotBackend` to shut down when too much time passes between creation of the backend and reception of the first action.
By default it is set to infinity, which disables it.

Also add a shutdown method to the backend which makes handling of the shutdown a bit easier.

## How I Tested

By modifying a demo and adding sleeps.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
