### PR TITLE
Do not set_cpu_dma_latency twice

### DIFF
--- a/include/robot_interfaces/monitored_robot_driver.hpp
+++ b/include/robot_interfaces/monitored_robot_driver.hpp
@@ -189,8 +189,6 @@ private:
      */
     void loop()
     {
-        real_time_tools::set_cpu_dma_latency(0);
-
         // wait for the first data
         while (!is_shutdown_ &&
                !action_start_logger_.wait_for_timeindex(0, 0.1))

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -175,8 +175,6 @@ private:
      */
     void loop()
     {
-        real_time_tools::set_cpu_dma_latency(0);
-
         // wait until first desired_action was received
         // ----------------------------
         while (!has_shutdown_request() &&


### PR DESCRIPTION
## Description

This is already called in `create_realtime_thread`, so there is no need
to call it again in the thread function itself.


## How I Tested

By running it on a real-time machine without write permission to /dev/cpu_dma_latency and checking how many warnings are printed (previously two, now only one).

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
