### PR TITLE
Release the GIL in the constructor

### DIFF
--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -13,6 +13,8 @@
 #include <cmath>
 #include <cstdint>
 
+#include <pybind11/embed.h>
+
 #include <real_time_tools/checkpoint_timer.hpp>
 #include <real_time_tools/process_manager.hpp>
 #include <real_time_tools/thread.hpp>
@@ -70,6 +72,11 @@ public:
 
     virtual ~RobotBackend()
     {
+        // Release the GIL when destructing the backend, as otherwise the
+        // program will get stuck in a dead lock in case the driver needs to run
+        // some Python code.
+        pybind11::gil_scoped_release release;
+
         request_shutdown();
         thread_->join();
     }


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

It is important to release the GIL when destructing the backend, as
otherwise the program will get stuck in a dead lock in case the driver
needs to run some Python code (as is the case with the pyBullet driver).

Unfortunately, there does not seem to be a non-intrusive way to do this
in the destructor when using pybind11.


## How I Tested

By running a script that was blocking before due to this issue (happens, when a backend instance is destroyed before the script ends (e.g. because it was created inside a function and and its scope ends).

## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] https://github.com/machines-in-motion/pybind11_catkin/pull/2

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
