### PR TITLE
Add unit test for max_number_of_actions

### DIFF
--- a/demos/demo.cpp
+++ b/demos/demo.cpp
@@ -13,6 +13,7 @@
 #include "robot_interfaces/robot_driver.hpp"
 #include "robot_interfaces/robot_frontend.hpp"
 #include "robot_interfaces/status.hpp"
+#include "robot_interfaces/example.hpp"
 
 #include <memory>
 
@@ -23,102 +24,8 @@
  * is represented by an integer
  */
 
-// Actions to be performed by robot, will be received by Driver
-// An action simply encapsulate two desired position value,
-// one for each dof
-class Action
-{
-public:
-    int values[2];
+using namespace robot_interfaces::example;
 
-    void print(bool backline)
-    {
-        std::cout << "action: " << values[0] << " " << values[1] << " ";
-        if (backline) std::cout << "\n";
-    }
-};
-
-// Read from the robot by Driver
-// An observation is the current position
-// for each dof
-class Observation
-{
-public:
-    int values[2];
-
-    void print(bool backline)
-    {
-        std::cout << "observation: " << values[0] << " " << values[1] << " ";
-        if (backline) std::cout << "\n";
-    }
-};
-
-// Send command to the robot and read observation from the robot
-// The dof positions simply becomes the ones set by the latest action,
-// capped between a min and a max value (0 and 1000)
-class Driver : public robot_interfaces::RobotDriver<Action, Observation>
-{
-public:
-    Driver(int min, int max) : min_(min), max_(max)
-    {
-    }
-
-    // at init dof are at min value
-    void initialize()
-    {
-        state_[0] = min_;
-        state_[1] = min_;
-    }
-
-    // just clip desired values
-    // between 0 and 1000
-    Action apply_action(const Action &action_to_apply)
-    {
-        Action applied;
-        for (unsigned int i = 0; i < 2; i++)
-        {
-            if (action_to_apply.values[i] > max_)
-            {
-                applied.values[i] = max_;
-            }
-            else if (action_to_apply.values[i] < min_)
-            {
-                applied.values[i] = min_;
-            }
-            else
-            {
-                applied.values[i] = action_to_apply.values[i];
-            }
-            // simulating the time if could take for a real
-            // robot to perform the action
-            usleep(1000);
-            state_[i] = applied.values[i];
-        }
-        return applied;
-    }
-
-    Observation get_latest_observation()
-    {
-        Observation observation;
-        observation.values[0] = state_[0];
-        observation.values[1] = state_[1];
-        return observation;
-    }
-
-    std::string get_error()
-    {
-        return "";  // no error
-    }
-
-    void shutdown()
-    {
-    }
-
-private:
-    int state_[2];
-    int min_;
-    int max_;
-};
 
 int main()
 {

--- a/include/robot_interfaces/example.hpp
+++ b/include/robot_interfaces/example.hpp
@@ -1,0 +1,129 @@
+/**
+ * @file
+ * license License BSD-3-Clause
+ * @copyright Copyright (c) 2019, Max Planck Gesellschaft.
+ *
+ * @brief Example driver and types for demo and testing purposes.
+ */
+
+#include <unistd.h>
+#include <iostream>
+#include <robot_interfaces/robot_driver.hpp>
+
+namespace robot_interfaces
+{
+namespace example
+{
+/**
+ * @brief Actions to be performed by robot, will be received by Driver.
+ *
+ * An action simply encapsulate two desired position value, one for each DOF.
+ */
+class Action
+{
+public:
+    int values[2];
+
+    void print(bool backline)
+    {
+        std::cout << "action: " << values[0] << " " << values[1] << " ";
+        if (backline)
+        {
+            std::cout << "\n";
+        }
+    }
+};
+
+/**
+ * @brief Observation read from the robot by Driver
+ *
+ * An observation is the current position for each DOF.
+ */
+class Observation
+{
+public:
+    int values[2];
+
+    void print(bool backline)
+    {
+        std::cout << "observation: " << values[0] << " " << values[1] << " ";
+        if (backline)
+        {
+            std::cout << "\n";
+        }
+    }
+};
+
+/**
+ * @brief Example Robot Driver.
+ *
+ * Send command to the robot and read observation from the robot.
+ * The DOF positions simply becomes the ones set by the latest action, capped
+ * between a min and a max value.
+ */
+class Driver : public robot_interfaces::RobotDriver<Action, Observation>
+{
+public:
+    Driver(int min, int max) : min_(min), max_(max)
+    {
+    }
+
+    // at init dof are at min value
+    void initialize()
+    {
+        state_[0] = min_;
+        state_[1] = min_;
+    }
+
+    // just clip desired values
+    // between 0 and 1000
+    Action apply_action(const Action &action_to_apply)
+    {
+        Action applied;
+        for (unsigned int i = 0; i < 2; i++)
+        {
+            if (action_to_apply.values[i] > max_)
+            {
+                applied.values[i] = max_;
+            }
+            else if (action_to_apply.values[i] < min_)
+            {
+                applied.values[i] = min_;
+            }
+            else
+            {
+                applied.values[i] = action_to_apply.values[i];
+            }
+            // simulating the time if could take for a real
+            // robot to perform the action
+            usleep(1000);
+            state_[i] = applied.values[i];
+        }
+        return applied;
+    }
+
+    Observation get_latest_observation()
+    {
+        Observation observation;
+        observation.values[0] = state_[0];
+        observation.values[1] = state_[1];
+        return observation;
+    }
+
+    std::string get_error()
+    {
+        return "";  // no error
+    }
+
+    void shutdown()
+    {
+    }
+
+private:
+    int state_[2];
+    int min_;
+    int max_;
+};
+
+}  // namespace example
+}  // namespace robot_interfaces

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -242,8 +242,8 @@ private:
             if (now - start_time > first_action_timeout_)
             {
                 Status status;
-                status.error_status = Status::ErrorStatus::BACKEND_ERROR;
-                status.error_message = "First action was not provided in time";
+                status.set_error(Status::ErrorStatus::BACKEND_ERROR,
+                                 "First action was not provided in time");
 
                 robot_data_->status->append(status);
 
@@ -264,8 +264,8 @@ private:
             if (max_number_of_actions_ > 0 && t >= max_number_of_actions_)
             {
                 // TODO this is not really an error
-                status.error_status = Status::ErrorStatus::BACKEND_ERROR;
-                status.error_message = "Maximum number of actions reached.";
+                status.set_error(Status::ErrorStatus::BACKEND_ERROR,
+                                 "Maximum number of actions reached.");
             }
 
             timer_.start();
@@ -301,17 +301,16 @@ private:
                 {
                     // No action provided and number of allowed repetitions
                     // of the previous action is exceeded --> Error
-                    status.error_status = Status::ErrorStatus::BACKEND_ERROR;
-                    status.error_message =
-                        "Next action was not provided in time";
+                    status.set_error(Status::ErrorStatus::BACKEND_ERROR,
+                                     "Next action was not provided in time");
                 }
             }
 
             std::string driver_error_msg = robot_driver_->get_error();
             if (!driver_error_msg.empty())
             {
-                status.error_status = Status::ErrorStatus::DRIVER_ERROR;
-                status.error_message = driver_error_msg;
+                status.set_error(Status::ErrorStatus::DRIVER_ERROR,
+                                 driver_error_msg);
             }
 
             robot_data_->status->append(status);

--- a/include/robot_interfaces/status.hpp
+++ b/include/robot_interfaces/status.hpp
@@ -52,6 +52,35 @@ struct Status : public Loggable
      */
     std::string error_message;
 
+    /**
+     * @brief Set error.
+     *
+     * If another error was set before, the old one is kept and the new one
+     * ignored.
+     *
+     * @param error_type  The type of the error.
+     * @param message  Error message.
+     */
+    void set_error(ErrorStatus error_type, const std::string& message)
+    {
+        // do not overwrite existing errors
+        if (!has_error())
+        {
+            this->error_status = error_type;
+            this->error_message = message;
+        }
+    }
+
+    /**
+     * @brief Check if an error is set.
+     *
+     * See error_status and error_message for more details on the error.
+     */
+    bool has_error() const
+    {
+        return this->error_status != Status::ErrorStatus::NO_ERROR;
+    }
+
     template <class Archive>
     void serialize(Archive& archive)
     {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,17 +5,19 @@
 macro(create_unittest test_name)
 
 # create the executable
-catkin_add_gtest(${test_name}_ut
+catkin_add_gtest(${test_name}
   main.cpp
-  test_${test_name}.cpp
+  ${test_name}.cpp
 )
-if(TARGET ${test_name}_ut)
+if(TARGET ${test_name})
     # link the dependencies to it
-    target_link_libraries(${test_name}_ut
+    target_link_libraries(${test_name}
         ${catkin_LIBRARIES}
+        global_signal_handler
     )
 endif()
 
 endmacro(create_unittest test_name)
 
-create_unittest(process_action)
+create_unittest(test_process_action)
+create_unittest(test_robot_backend)

--- a/tests/test_robot_backend.cpp
+++ b/tests/test_robot_backend.cpp
@@ -1,0 +1,69 @@
+/**
+ * @file
+ * @brief Tests for RobotBackend
+ * @copyright Copyright (c) 2019, Max Planck Gesellschaft.
+ */
+#include <gtest/gtest.h>
+#include <robot_interfaces/example.hpp>
+#include <robot_interfaces/robot_backend.hpp>
+#include <robot_interfaces/robot_frontend.hpp>
+
+using namespace robot_interfaces;
+
+/**
+ * @brief Fixture for the backend tests.
+ */
+class TestRobotBackend : public ::testing::Test
+{
+protected:
+    typedef example::Action Action;
+    typedef example::Observation Observation;
+    typedef robot_interfaces::Status Status;
+    typedef robot_interfaces::RobotBackend<Action, Observation> Backend;
+    typedef robot_interfaces::SingleProcessRobotData<Action, Observation> Data;
+    typedef robot_interfaces::RobotFrontend<Action, Observation> Frontend;
+
+    std::shared_ptr<example::Driver> driver;
+    std::shared_ptr<Data> data;
+
+    void SetUp() override
+    {
+        driver = std::make_shared<example::Driver>(0, 1000);
+        data = std::make_shared<Data>();
+    }
+};
+
+// Test if the "max_number_of_actions" feature is working as expected
+TEST_F(TestRobotBackend, max_number_of_actions)
+{
+    constexpr bool real_time_mode = true;
+    constexpr double first_action_timeout =
+        std::numeric_limits<double>::infinity();
+    constexpr uint32_t max_number_of_actions = 10;
+
+    Backend backend(driver,
+                    data,
+                    real_time_mode,
+                    first_action_timeout,
+                    max_number_of_actions);
+    backend.initialize();
+    Frontend frontend(data);
+
+    Action action;
+    action.values[0] = 42;
+    action.values[1] = 42;
+
+    robot_interfaces::TimeIndex t;
+    for (uint32_t i = 0; i < max_number_of_actions; i++)
+    {
+        t = frontend.append_desired_action(action);
+        Status status = frontend.get_status(t);
+
+        ASSERT_FALSE(status.has_error());
+    }
+
+    auto status = frontend.get_status(t + 1);
+    ASSERT_TRUE(status.has_error());
+    ASSERT_EQ(Status::ErrorStatus::BACKEND_ERROR, status.error_status);
+    ASSERT_EQ("Maximum number of actions reached.", status.error_message);
+}


### PR DESCRIPTION
## Description

- Move the dummy driver from demo.cpp to a separate file example.hpp so
  it can also be used in unit tests.
- Add `set_error()` and `has_error()` to `Status`.  Only keep the first
  error that occurs, i.e. if `set_error()` is called on a status object
  that already has an error, the error of the second call is discarded.
- Add a unit test file for `RobotBackend`.  So far, add only one test
  for the `max_number_of_actions` feature.

@vincentberenz I moved the driver from your demo to a separate file as I think it is quite useful for unit tests.  However, this makes the demo.cpp less self-contained, so I'm a bit unsure if it would be better to have it in both places (i.e. add the new example.hpp which can be used for tests but also keep a copy in demo.cpp).  What do you think?

## How I Tested

    catkin run_tests robot_interfaces --no-deps

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
