### PR TITLE
Clean up RobotFrontend a bit

### DIFF
--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -25,6 +25,8 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl_bind.h>
 
+#include <robot_interfaces/robot_frontend.hpp>
+
 namespace robot_interfaces
 {
 /**
@@ -139,8 +141,19 @@ void create_python_bindings(pybind11::module &m)
         .def("get_status",
              &Types::Frontend::get_status,
              pybind11::call_guard<pybind11::gil_scoped_release>())
-        .def("get_time_stamp_ms",
-             &Types::Frontend::get_time_stamp_ms,
+        // TODO get_time_stamp_ms is deprecated, remove it some time in the near
+        // future.
+        .def(
+            "get_time_stamp_ms",
+            [](pybind11::object &self, const TimeIndex &t) {
+                auto warnings = pybind11::module::import("warnings");
+                warnings.attr("warn")(
+                    "get_time_stamp_ms() is deprecated, use get_timestamp_ms() "
+                    "instead.");
+                return self.attr("get_timestamp_ms")(t);
+            })
+        .def("get_timestamp_ms",
+             &Types::Frontend::get_timestamp_ms,
              pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("append_desired_action",
              &Types::Frontend::append_desired_action,

--- a/include/robot_interfaces/robot_frontend.hpp
+++ b/include/robot_interfaces/robot_frontend.hpp
@@ -45,28 +45,28 @@ public:
     {
     }
 
-    Observation get_observation(const TimeIndex &t)
+    Observation get_observation(const TimeIndex &t) const
     {
         return (*robot_data_->observation)[t];
     }
-    Action get_desired_action(const TimeIndex &t)
+    Action get_desired_action(const TimeIndex &t) const
     {
         return (*robot_data_->desired_action)[t];
     }
-    Action get_applied_action(const TimeIndex &t)
+    Action get_applied_action(const TimeIndex &t) const
     {
         return (*robot_data_->applied_action)[t];
     }
-    Status get_status(const TimeIndex &t)
+    Status get_status(const TimeIndex &t) const
     {
         return (*robot_data_->status)[t];
     }
 
-    TimeStamp get_time_stamp_ms(const TimeIndex &t)
+    TimeStamp get_time_stamp_ms(const TimeIndex &t) const
     {
         return robot_data_->observation->timestamp_ms(t);
     }
-    TimeIndex get_current_timeindex()
+    TimeIndex get_current_timeindex() const
     {
         return robot_data_->observation->newest_timeindex();
     }
@@ -114,7 +114,7 @@ public:
         return robot_data_->desired_action->newest_timeindex();
     }
 
-    void wait_until_timeindex(const TimeIndex &t)
+    void wait_until_timeindex(const TimeIndex &t) const
     {
         robot_data_->observation->timestamp_ms(t);
     }

--- a/include/robot_interfaces/robot_frontend.hpp
+++ b/include/robot_interfaces/robot_frontend.hpp
@@ -62,7 +62,12 @@ public:
         return (*robot_data_->status)[t];
     }
 
-    TimeStamp get_time_stamp_ms(const TimeIndex &t) const
+    //! @deprecated Use get_timestamp_ms instead
+    [[deprecated]] TimeStamp get_time_stamp_ms(const TimeIndex &t) const
+    {
+        return get_timestamp_ms(t);
+    }
+    TimeStamp get_timestamp_ms(const TimeIndex &t) const
     {
         return robot_data_->observation->timestamp_ms(t);
     }


### PR DESCRIPTION
## Description

- Make methods in `RobotFrontend` const where possible.
- Rename `get_time_stamp_ms` to `get_timestamp_ms` for consistency.  Keep old name for compatibility but mark it deprecated.


## How I Tested

By calling both `get_time_stamp_ms()` and `get_timestamp_ms()` in a test script.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
