### PR TITLE
Make methods of SensorFrontend const

### DIFF
--- a/include/robot_interfaces/sensors/sensor_frontend.hpp
+++ b/include/robot_interfaces/sensors/sensor_frontend.hpp
@@ -40,21 +40,21 @@ public:
     {
     }
 
-    ObservationType get_observation(const TimeIndex &t)
+    ObservationType get_observation(const TimeIndex t) const
     {
         return (*sensor_data_->observation)[t];
     }
 
-    ObservationType get_latest_observation()
+    ObservationType get_latest_observation() const
     {
         return sensor_data_->observation->newest_element();
     }
 
-    TimeStamp get_timestamp_ms(const TimeIndex &t)
+    TimeStamp get_timestamp_ms(const TimeIndex t) const
     {
         return sensor_data_->observation->timestamp_ms(t);
     }
-    TimeIndex get_current_timeindex()
+    TimeIndex get_current_timeindex() const
     {
         return sensor_data_->observation->newest_timeindex();
     }


### PR DESCRIPTION
## Description

- Make methods of SensorFrontend const (needed so they can be called in other const functions).
- Don't use references for time index.  It is just an integer, so there is no benefit from using a const reference.

## How I Tested

Compiled.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
