### PR TITLE
Fix logging of tip forces

### DIFF
--- a/include/robot_interfaces/n_finger_observation.hpp
+++ b/include/robot_interfaces/n_finger_observation.hpp
@@ -58,7 +58,7 @@ struct NFingerObservation : public Loggable
         JointVector::Map(&result[0][0], position.size()) = position;
         JointVector::Map(&result[1][0], velocity.size()) = velocity;
         JointVector::Map(&result[2][0], torque.size()) = torque;
-        FingerVector::Map(&result[0][0], tip_force.size()) = tip_force;
+        FingerVector::Map(&result[3][0], tip_force.size()) = tip_force;
 
         return result;
     }

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -148,7 +148,7 @@ public:
         {
             if (field_data[i].size() == 1)
             {
-                std::string temp = field_name[i];
+                std::string temp = identifier + "_" + field_name[i];
                 header.push_back(temp);
             }
             else


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

1. Add the message type prefix (e.g. "observation_") also for scalar
   values.
2. Write the tip force to the correct part of the data array (previously
   was overwriting joint positions).


## How I Tested
By running the logger in with simulation backend and examining the resulting file.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
