### PR TITLE
RobotFrontend: Use same method names in C++ and Python

### DIFF
--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -158,10 +158,28 @@ void create_python_bindings(pybind11::module &m)
         .def("append_desired_action",
              &Types::Frontend::append_desired_action,
              pybind11::call_guard<pybind11::gil_scoped_release>())
+        // TODO: deprecated, remove in near future
         .def("wait_until_time_index",
+             [](pybind11::object &self, const TimeIndex &t) {
+                 auto warnings = pybind11::module::import("warnings");
+                 warnings.attr("warn")(
+                     "wait_until_time_index() is deprecated, use "
+                     "wait_until_timeindex() instead.");
+                 return self.attr("wait_until_timeindex")(t);
+             })
+        .def("wait_until_timeindex",
              &Types::Frontend::wait_until_timeindex,
              pybind11::call_guard<pybind11::gil_scoped_release>())
+        // TODO: deprecated, remove in near future
         .def("get_current_time_index",
+             [](pybind11::object &self) {
+                 auto warnings = pybind11::module::import("warnings");
+                 warnings.attr("warn")(
+                     "get_current_time_index() is deprecated, use "
+                     "get_current_timeindex() instead.");
+                 return self.attr("get_current_timeindex")();
+             })
+        .def("get_current_timeindex",
              &Types::Frontend::get_current_timeindex,
              pybind11::call_guard<pybind11::gil_scoped_release>());
 


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
Be consistent with naming, i.e. do not use "time_index" in the Python
bindings when it is "timeindex" in C++.
Keep the old name for now but raise a warning when it is used (using 
the same pattern already used in `get_time_stamp_ms`).

## How I Tested

By running a script that calls both variants.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
