### PR TITLE
Use std::thread for logger

### DIFF
--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -19,10 +19,6 @@
 #include <mpi_cpp_tools/dynamical_systems.hpp>
 #include <mpi_cpp_tools/math.hpp>
 
-#include <real_time_tools/process_manager.hpp>
-#include <real_time_tools/thread.hpp>
-#include <real_time_tools/timer.hpp>
-
 #include <robot_interfaces/loggable.hpp>
 #include <robot_interfaces/status.hpp>
 
@@ -262,7 +258,7 @@ public:
         while (!stop_was_called_ &&
                !(logger_data_->desired_action->length() > 0))
         {
-            real_time_tools::Timer::sleep_until_sec(0.1);
+            std::this_thread::sleep_for(std::chrono::milliseconds(100));
         }
 
         index_ = logger_data_->observation->newest_timeindex();


### PR DESCRIPTION
## Description

Use a standard thread for the logger instead of a real-time one.
The logger is not real-time critical and by using a standard thread, it
is less likely to mess with the really time-critical robot threads.



## How I Tested

On TriFingerPro


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [ ] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
