### PR TITLE
Refactor Logger and add method to log without background thread

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,6 @@ set(CMAKE_INSTALL_RPATH ${CMAKE_INSTALL_PREFIX}/lib)
 set(CATKIN_PKGS ${CATKIN_PKGS}
   mpi_cmake_modules
   real_time_tools
-  mpi_cpp_tools
   pybind11_catkin
   time_series
   signal_handler

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -188,7 +188,11 @@ void create_python_bindings(pybind11::module &m)
              pybind11::arg("robot_data"),
              pybind11::arg("block_size") = 100)
         .def("start", &Types::Logger::start)
-        .def("stop", &Types::Logger::stop);
+        .def("stop", &Types::Logger::stop)
+        .def("write_current_buffer",
+             &Types::Logger::write_current_buffer,
+             pybind11::arg("filename"),
+             pybind11::arg("start_index") = 0);
 }
 
 }  // namespace robot_interfaces

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -184,7 +184,9 @@ void create_python_bindings(pybind11::module &m)
              pybind11::call_guard<pybind11::gil_scoped_release>());
 
     pybind11::class_<typename Types::Logger>(m, "Logger")
-        .def(pybind11::init<typename Types::BaseDataPtr, int>())
+        .def(pybind11::init<typename Types::BaseDataPtr, int>(),
+             pybind11::arg("robot_data"),
+             pybind11::arg("block_size") = 100)
         .def("start", &Types::Logger::start)
         .def("stop", &Types::Logger::stop);
 }

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -15,12 +15,7 @@
 #include <limits>
 #include <thread>
 
-#include <Eigen/Eigen>
-
-#include <mpi_cpp_tools/basic_tools.hpp>
-#include <mpi_cpp_tools/dynamical_systems.hpp>
-#include <mpi_cpp_tools/math.hpp>
-
+#include <robot_interfaces/robot_data.hpp>
 #include <robot_interfaces/loggable.hpp>
 #include <robot_interfaces/status.hpp>
 

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -77,6 +77,7 @@ public:
      */
     void start(const std::string &filename)
     {
+        stop_was_called_ = false;
         output_file_name_ = filename;
         thread_ = std::thread(&RobotLogger<Action, Observation>::loop, this);
     }

--- a/license.txt
+++ b/license.txt
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2019, New York University and Max Planck Gesellshaft.
+Copyright (c) 2019, New York University and Max Planck Gesellschaft.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/package.xml
+++ b/package.xml
@@ -3,11 +3,15 @@
   <name>robot_interfaces</name>
   <version>1.0.0</version>
   <description>
-    This package provides C++ interfaces (purely virtual classes) for different robots. The idea is to use this interface both for the real robots as well as the simulators.
+    This package provides C++ interfaces (purely virtual classes) for different
+    robots. The idea is to use this interface both for the real robots as well
+    as the simulators.
   </description>
   <author email="manuel.wuthrich@gmail.com">Manuel Wuthrich</author>
   <maintainer email="manuel.wuthrich@gmail.com">Manuel Wuthrich</maintainer>
-  <license>TODO</license>
+  <maintainer email="felix.widmaier@tue.mpg.de">Felix Widmaier</maintainer>
+  <license>BSD 3-Clause</license>
+
   <buildtool_depend>catkin</buildtool_depend>
 
   <depend>mpi_cmake_modules</depend>

--- a/package.xml
+++ b/package.xml
@@ -12,7 +12,6 @@
 
   <depend>mpi_cmake_modules</depend>
   <depend>real_time_tools</depend>
-  <depend>mpi_cpp_tools</depend>
   <depend>pybind11_catkin</depend>
   <depend>time_series</depend>
   <depend>signal_handler</depend>


### PR DESCRIPTION
## Description

- Some refactoring to simplify the code a bit and to make the following changes easier.
- Implement method `write_current_buffer()` which writes content from the current time series buffer to a log file without running a thread in the background.  Use this to log data if the time span is short enough to be fully contained in the time series buffer.
- If the specified log file already exists, do not append to it anymore but overwrite the existing file.  The appending resulted in invalid files as the header was also written again and I anyway don't see a use-case where one would want to log independent sequences to the same file.
- Some bugfixes:
  - enable restarting after stopping
  - detect if stop is called without starting it first and don't attempt to write to the file in this case.


## How I Tested

With the `demo_data_logging.py` demo and some modifications of it to test the various cases.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
