### PR TITLE
Revert "Also check if GIL is actually held before releasing it"

### DIFF
--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -79,9 +79,9 @@ public:
         // pybind11::gil_scoped_release causes a segfault when the class is used
         // directly from C++ (i.e. no Python interpreter running).
         // Best workaround found so far is to explicitly check if Python is
-        // initialized or not and if the GIL is currently held...
+        // initialized or not...
         // See https://github.com/pybind/pybind11/issues/2177
-        if (Py_IsInitialized() && PyGILState_Check())
+        if (Py_IsInitialized())
         {
             // Release the GIL when destructing the backend, as otherwise the
             // program will get stuck in a dead lock in case the driver needs to


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

This reverts commit cb0832c10c2d0d6c9cd61f89b096d6a142a9b5d5.

I just learned that `PyGILState_Check()` was only added in Python 3.4 so on a normal build (based on Python 2), this will not be available.  I did not notice this because locally I build with Python 3 but after the change bamboo is failing...
