### PR TITLE
RobotLogger:  Option to specify end index

### DIFF
--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -192,7 +192,8 @@ void create_python_bindings(pybind11::module &m)
         .def("write_current_buffer",
              &Types::Logger::write_current_buffer,
              pybind11::arg("filename"),
-             pybind11::arg("start_index") = 0);
+             pybind11::arg("start_index") = 0,
+             pybind11::arg("end_index") = -1);
 }
 
 }  // namespace robot_interfaces


### PR DESCRIPTION
## Description
Add an option to `write_current_buffer()` to specify the `end_index`.
This way a specific interval of time steps can be logged (will be needed for the submission system).

## How I Tested

Using a modified demo and the submission system script.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
