### PR TITLE
Add RobotBackend::wait_until_first_action()

### DIFF
--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -98,6 +98,9 @@ void create_python_bindings(pybind11::module &m)
         .def("initialize",
              &Types::Backend::initialize,
              pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("wait_until_first_action",
+             &Types::Backend::wait_until_first_action,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("wait_until_terminated",
              &Types::Backend::wait_until_terminated,
              pybind11::call_guard<pybind11::gil_scoped_release>());

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -141,6 +141,16 @@ public:
     }
 
     /**
+     * @brief Wait until the first desired action is received.
+     */
+    void wait_until_first_action() const
+    {
+        while (!has_shutdown_request() &&
+               !robot_data_->desired_action->wait_for_timeindex(0, 0.1))
+        {}
+    }
+
+    /**
      * @brief Wait until the backend loop terminates.
      */
     void wait_until_terminated() const


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add method to RobotBackend to wait for the first desired action to be
received.


## How I Tested

Used in trifinger backend to start camera log only when user starts sending actions.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
