### PR TITLE
Use factories of MultiprocessTimeSeries

### DIFF
--- a/include/robot_interfaces/sensors/sensor_data.hpp
+++ b/include/robot_interfaces/sensors/sensor_data.hpp
@@ -80,13 +80,16 @@ public:
         {
             // the master instance is in charge of cleaning the memory
             time_series::clear_memory(shared_memory_id);
+
+            this->observation = time_series::MultiprocessTimeSeries<
+                Observation>::create_leader_ptr(shared_memory_id,
+                                                history_length);
         }
-
-        const bool clean_on_destruction = is_master;
-
-        this->observation =
-            std::make_shared<time_series::MultiprocessTimeSeries<Observation>>(
-                shared_memory_id, history_length, clean_on_destruction);
+        else
+        {
+            this->observation = time_series::MultiprocessTimeSeries<
+                Observation>::create_follower_ptr(shared_memory_id);
+        }
     }
 };
 


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Use the `create_leader_ptr` and `create_follower_ptr` factories of
`MultiprocessTimeSeries` when creating them.  In case of follower, the
passed `history_size` is ignored as the actual size of the time series
will be read from the shared memory.

This is just a quick intermediate solution.  The proper one would be to add separate factory methods here as well to avoid confusion with `history_size` being ignored in case of follower.  However, this will require bigger changes on the code which I prefer to do at a later time.

## How I Tested

Running with backend and frontend in separate processes on TriFingerPro.


## Do not merge before

[//]: # "Link other open pull request here that need to be merged first."
[//]: # "Remove this section if it does not apply."

- [x] https://github.com/machines-in-motion/time_series/pull/14

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
