### PR TITLE
Log time series timestamps in sensor log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 ######################
 # set up the project #
 ######################
-cmake_minimum_required(VERSION 2.8.3)
+cmake_minimum_required(VERSION 3.1)
 
 project(robot_interfaces)
 
@@ -9,7 +9,11 @@ project(robot_interfaces)
 if(NOT ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
   set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wl,--no-as-needed")
 endif()
-set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wextra")
+set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+
+# Specify C++ Standard
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED on)
 
 # stop build on first error
 string(APPEND CMAKE_CXX_FLAGS " -Wfatal-errors")

--- a/include/robot_interfaces/sensors/pybind_sensors.hpp
+++ b/include/robot_interfaces/sensors/pybind_sensors.hpp
@@ -77,7 +77,8 @@ void create_sensor_bindings(pybind11::module& m)
     pybind11::class_<LogReader, std::shared_ptr<LogReader>>(m, "LogReader")
         .def(pybind11::init<std::string>())
         .def("read_file", &LogReader::read_file)
-        .def_readonly("data", &LogReader::data);
+        .def_readonly("data", &LogReader::data)
+        .def_readonly("timestamps", &LogReader::timestamps);
 }
 
 }  // namespace robot_interfaces


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add the timestamps of the "observation" time series to the sensor log.  This is needed to be able to make the same "robot time index to camera time index"-matching as during runtime.

Note: This will make older senor log files unreadable.  To better handle this in the future, add a "format_version" at the beginning of the log file.  In case of future changes of the file format, the reader can first check the version and chose the correct deserialization method for the rest of the file.

Bump C++ version to 17 for the structured binding feature (`auto [foo, bar] = tuple`).


## How I Tested

Recorded data with the new logger and verified it is readable by the new log reader.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
