### PR TITLE
Store robot log in binary format

### DIFF
--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -24,6 +24,7 @@
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl_bind.h>
+#include <pybind11/stl.h>
 
 #include <robot_interfaces/robot_frontend.hpp>
 
@@ -196,7 +197,19 @@ void create_python_bindings(pybind11::module &m)
              &Types::Logger::write_current_buffer,
              pybind11::arg("filename"),
              pybind11::arg("start_index") = 0,
+             pybind11::arg("end_index") = -1)
+        .def("write_current_buffer_binary",
+             &Types::Logger::write_current_buffer_binary,
+             pybind11::arg("filename"),
+             pybind11::arg("start_index") = 0,
              pybind11::arg("end_index") = -1);
+
+    pybind11::class_<typename Types::BinaryLogReader,
+                     std::shared_ptr<typename Types::BinaryLogReader>>(
+        m, "BinaryLogReader")
+        .def(pybind11::init<std::string>())
+        .def("read_file", &Types::BinaryLogReader::read_file)
+        .def_readonly("data", &Types::BinaryLogReader::data);
 }
 
 }  // namespace robot_interfaces

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -23,8 +23,8 @@
 
 #include <pybind11/eigen.h>
 #include <pybind11/pybind11.h>
-#include <pybind11/stl_bind.h>
 #include <pybind11/stl.h>
+#include <pybind11/stl_bind.h>
 
 #include <robot_interfaces/robot_frontend.hpp>
 
@@ -186,6 +186,14 @@ void create_python_bindings(pybind11::module &m)
         .def("get_current_timeindex",
              &Types::Frontend::get_current_timeindex,
              pybind11::call_guard<pybind11::gil_scoped_release>());
+
+    pybind11::class_<typename Types::LogEntry>(m, "LogEntry")
+        .def_readwrite("timeindex", &Types::LogEntry::timeindex)
+        .def_readwrite("timestamp", &Types::LogEntry::timestamp)
+        .def_readwrite("status", &Types::LogEntry::status)
+        .def_readwrite("observation", &Types::LogEntry::observation)
+        .def_readwrite("desired_action", &Types::LogEntry::desired_action)
+        .def_readwrite("applied_action", &Types::LogEntry::applied_action);
 
     pybind11::class_<typename Types::Logger>(m, "Logger")
         .def(pybind11::init<typename Types::BaseDataPtr, int>(),

--- a/include/robot_interfaces/robot_log_entry.hpp
+++ b/include/robot_interfaces/robot_log_entry.hpp
@@ -1,0 +1,39 @@
+/**
+ * \file
+ * \copyright Copyright (c) 2020, Max Planck Gesellschaft.
+ */
+#pragma once
+
+#include <time_series/interface.hpp>
+
+#include <robot_interfaces/status.hpp>
+
+namespace robot_interfaces
+{
+/**
+ * @brief Robot log entry used for binary log format.
+ *
+ * Contains all the robot data of one time step.
+ */
+template <typename Action, typename Observation>
+struct RobotLogEntry
+{
+    time_series::Index timeindex;
+    time_series::Timestamp timestamp;
+    Status status;
+    Observation observation;
+    Action desired_action;
+    Action applied_action;
+
+    template <class Archive>
+    void serialize(Archive& archive)
+    {
+        archive(timeindex,
+                timestamp,
+                status,
+                observation,
+                desired_action,
+                applied_action);
+    }
+};
+}  // namespace robot_interfaces

--- a/include/robot_interfaces/robot_log_reader.hpp
+++ b/include/robot_interfaces/robot_log_reader.hpp
@@ -1,0 +1,66 @@
+/**
+ * @file
+ * @brief API to read the data from a robot log file.
+ * @copyright 2020, Max Planck Gesellschaft. All rights reserved.
+ * @license BSD 3-clause
+ */
+#pragma once
+
+#include <fstream>
+#include <vector>
+
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/tuple.hpp>
+#include <cereal/types/vector.hpp>
+
+#include <robot_interfaces/status.hpp>
+
+namespace robot_interfaces
+{
+/**
+ * @brief Read the data from a robot log file.
+ *
+ * The data is read from the specified file and stored to the `data` member
+ * where it can be accessed.
+ */
+template <typename Action, typename Observation>
+class RobotBinaryLogReader
+{
+public:
+    typedef std::tuple<long int, double, Status, Observation, Action, Action>
+        LogEntry;
+
+    std::vector<LogEntry> data;
+
+    //! @copydoc RobotBinaryLogReader::read_file()
+    RobotBinaryLogReader(const std::string &filename)
+    {
+        read_file(filename);
+    }
+
+    /**
+     * @brief Read data from the specified file.
+     *
+     * The data is stored to RobotBinaryLogReader::data.
+     *
+     * @param filename Path to the robot log file.
+     */
+    void read_file(const std::string &filename)
+    {
+        std::ifstream infile(filename, std::ios::binary);
+        cereal::BinaryInputArchive archive(infile);
+
+        std::uint32_t format_version;
+        archive(format_version);
+
+        if (format_version != 1)
+        {
+            throw std::runtime_error("Incompatible log file format.");
+        }
+
+        archive(data);
+    }
+};
+
+}  // namespace robot_interfaces
+

--- a/include/robot_interfaces/robot_log_reader.hpp
+++ b/include/robot_interfaces/robot_log_reader.hpp
@@ -13,7 +13,7 @@
 #include <cereal/types/tuple.hpp>
 #include <cereal/types/vector.hpp>
 
-#include <robot_interfaces/status.hpp>
+#include <robot_interfaces/robot_log_entry.hpp>
 
 namespace robot_interfaces
 {
@@ -27,8 +27,7 @@ template <typename Action, typename Observation>
 class RobotBinaryLogReader
 {
 public:
-    typedef std::tuple<long int, double, Status, Observation, Action, Action>
-        LogEntry;
+    typedef RobotLogEntry<Action, Observation> LogEntry;
 
     std::vector<LogEntry> data;
 
@@ -53,7 +52,7 @@ public:
         std::uint32_t format_version;
         archive(format_version);
 
-        if (format_version != 1)
+        if (format_version != 2)
         {
             throw std::runtime_error("Incompatible log file format.");
         }

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -15,6 +15,10 @@
 #include <limits>
 #include <thread>
 
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/vector.hpp>
+#include <cereal/types/tuple.hpp>
+
 #include <robot_interfaces/loggable.hpp>
 #include <robot_interfaces/robot_data.hpp>
 #include <robot_interfaces/status.hpp>
@@ -176,6 +180,87 @@ public:
         }
 
         append_robot_data_to_file(start_index, end_index - start_index);
+    }
+
+    void write_current_buffer_binary(const std::string filename,
+                              long int start_index = 0,
+                              long int end_index = -1)
+    {
+        if (is_running_)
+        {
+            throw std::runtime_error(
+                "RobotLogger is currently running.  Call stop() first.");
+        }
+
+        // set end_index to the current time index if not set or if it is in the
+        // future.
+        long int t = logger_data_->observation->newest_timeindex();
+        if (end_index < 0)
+        {
+            end_index = t;
+        }
+        else
+        {
+            end_index = std::min(t, end_index);
+        }
+
+        long int block_size = end_index - start_index;
+
+        // TODO use a struct, so fields have names
+        typedef std::tuple<long int, double, Status, Observation, Action, Action> LogEntry;
+
+        std::vector<LogEntry> log_data;
+        log_data.reserve(block_size);
+
+        for (long int t = start_index;
+             t < std::min(start_index + block_size,
+                          logger_data_->observation->newest_timeindex());
+             t++)
+        {
+            try
+            {
+                Action applied_action = (*logger_data_->applied_action)[t];
+                Action desired_action = (*logger_data_->desired_action)[t];
+                Observation observation = (*logger_data_->observation)[t];
+                Status status = (*logger_data_->status)[t];
+                auto timestamp = logger_data_->observation->timestamp_s(t);
+
+                log_data.push_back(std::make_tuple(
+                            t,
+                            timestamp,
+                            status,
+                            observation,
+                            desired_action,
+                            applied_action));
+            }
+            catch (const std::invalid_argument &e)
+            {
+                auto t_oldest = logger_data_->observation->oldest_timeindex();
+                auto diff = t_oldest - t;
+
+                std::cout << "Warning: Trying to log time step " << t
+                          << " which is not in the buffer anymore.  Skip "
+                          << diff << " steps to time step " << (t_oldest + 1)
+                          << std::endl;
+
+                // Note that t is incremented in the next iteration, so logging
+                // continues from t_oldest + 1.  This means that one potentially
+                // available step is dropped but it lowers the risk that the
+                // same issue happens immediately again as t_oldest may drop out
+                // of the buffer until it is processed in the next iteration.
+                t = t_oldest;
+            }
+        }
+
+
+        std::ofstream outfile(filename, std::ios::binary);
+        cereal::BinaryOutputArchive archive(outfile);
+
+        // add version information to the output file (this can be used while
+        // loading when the data format changes
+        const std::uint32_t format_version = 1;
+
+        archive(format_version, log_data);
     }
 
 private:

--- a/include/robot_interfaces/types.hpp
+++ b/include/robot_interfaces/types.hpp
@@ -12,6 +12,7 @@
 #include "robot_data.hpp"
 #include "robot_frontend.hpp"
 #include "robot_logger.hpp"
+#include "robot_log_reader.hpp"
 
 namespace robot_interfaces
 {
@@ -35,6 +36,7 @@ struct RobotInterfaceTypes
     typedef std::shared_ptr<Frontend> FrontendPtr;
 
     typedef RobotLogger<Action, Observation> Logger;
+    typedef RobotBinaryLogReader<Action, Observation> BinaryLogReader;
 };
 
 }  // namespace robot_interfaces

--- a/include/robot_interfaces/types.hpp
+++ b/include/robot_interfaces/types.hpp
@@ -12,6 +12,7 @@
 #include "robot_data.hpp"
 #include "robot_frontend.hpp"
 #include "robot_logger.hpp"
+#include "robot_log_entry.hpp"
 #include "robot_log_reader.hpp"
 
 namespace robot_interfaces
@@ -35,6 +36,7 @@ struct RobotInterfaceTypes
     typedef RobotFrontend<Action, Observation> Frontend;
     typedef std::shared_ptr<Frontend> FrontendPtr;
 
+    typedef RobotLogEntry<Action, Observation> LogEntry;
     typedef RobotLogger<Action, Observation> Logger;
     typedef RobotBinaryLogReader<Action, Observation> BinaryLogReader;
 };


### PR DESCRIPTION
## Description

Add option to store the robot log in binary format using serialization by cereal.

This results in significantly smaller log files (~100 MB instead of ~240 MB for 2 minutes on TriFingerPro) and is easier to load in C++ applications.

This is is added in addition to the CSV-log (so all existing functionality is preserved) and only available in the "write current buffer" variant.


## How I Tested

By producing both csv and binary log on a test run on a TriFingerPro platform, converting the binary to csv and verifying that it results in the exact same values as when directly logging to CSV.  The script for converting will be added in a coming PR to robot_fingers.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
