### PR TITLE
Start sensor log at oldest time index, not newest

### DIFF
--- a/include/robot_interfaces/sensors/sensor_logger.hpp
+++ b/include/robot_interfaces/sensors/sensor_logger.hpp
@@ -141,7 +141,7 @@ private:
     //! Get observations from sensor_data_ and add them to the buffer.
     void loop()
     {
-        auto t = sensor_data_->observation->newest_timeindex();
+        auto t = sensor_data_->observation->oldest_timeindex();
 
         while (enabled_)
         {


### PR DESCRIPTION

[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description
Start sensor log at oldest time index, not newest. This should ensure that the sensor observation which was active at robot
time step 0 is included in the log when starting the log after the first robot action is received.


## How I Tested

Running it on the submission system for a while.  Out of 321 tested log files, all of them had a camera observation already for the first robot step.

In a previous test without this change, out of 263 log files, 14 did not have a camera observation for the first few robot steps (varying between 1-10).

Note that with current settings, this change increases the camera log on TriFingerPro by around 20 MB (from ~275 MB to ~295 MB).

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
