### PR TITLE
Add public "shutdown" method to SensorBackend and relese GIL

### DIFF
--- a/include/robot_interfaces/sensors/pybind_sensors.hpp
+++ b/include/robot_interfaces/sensors/pybind_sensors.hpp
@@ -54,7 +54,10 @@ void create_sensor_bindings(pybind11::module& m)
     pybind11::class_<SensorBackend<ObservationType>>(m, "Backend")
         .def(pybind11::init<
              typename std::shared_ptr<SensorDriver<ObservationType>>,
-             typename std::shared_ptr<BaseData>>());
+             typename std::shared_ptr<BaseData>>())
+        .def("shutdown",
+             &SensorBackend<ObservationType>::shutdown,
+             pybind11::call_guard<pybind11::gil_scoped_release>());
 
     pybind11::class_<SensorFrontend<ObservationType>>(m, "Frontend")
         .def(pybind11::init<typename std::shared_ptr<BaseData>>())

--- a/include/robot_interfaces/sensors/pybind_sensors.hpp
+++ b/include/robot_interfaces/sensors/pybind_sensors.hpp
@@ -62,26 +62,44 @@ void create_sensor_bindings(pybind11::module& m)
     pybind11::class_<SensorFrontend<ObservationType>>(m, "Frontend")
         .def(pybind11::init<typename std::shared_ptr<BaseData>>())
         .def("get_latest_observation",
-             &SensorFrontend<ObservationType>::get_latest_observation)
+             &SensorFrontend<ObservationType>::get_latest_observation,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("get_observation",
-             &SensorFrontend<ObservationType>::get_observation)
+             &SensorFrontend<ObservationType>::get_observation,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("get_timestamp_ms",
-             &SensorFrontend<ObservationType>::get_timestamp_ms)
+             &SensorFrontend<ObservationType>::get_timestamp_ms,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("get_current_timeindex",
-             &SensorFrontend<ObservationType>::get_current_timeindex);
+             &SensorFrontend<ObservationType>::get_current_timeindex,
+             pybind11::call_guard<pybind11::gil_scoped_release>());
 
     pybind11::class_<Logger, std::shared_ptr<Logger>>(m, "Logger")
         .def(pybind11::init<typename std::shared_ptr<BaseData>, size_t>())
-        .def("start", &Logger::start)
-        .def("stop", &Logger::stop)
-        .def("reset", &Logger::reset)
-        .def("stop_and_save", &Logger::stop_and_save);
+        .def("start",
+             &Logger::start,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("stop",
+             &Logger::stop,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("reset",
+             &Logger::reset,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("stop_and_save",
+             &Logger::stop_and_save,
+             pybind11::call_guard<pybind11::gil_scoped_release>());
 
     pybind11::class_<LogReader, std::shared_ptr<LogReader>>(m, "LogReader")
         .def(pybind11::init<std::string>())
-        .def("read_file", &LogReader::read_file)
-        .def_readonly("data", &LogReader::data)
-        .def_readonly("timestamps", &LogReader::timestamps);
+        .def("read_file",
+             &LogReader::read_file,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def_readonly("data",
+                      &LogReader::data,
+                      pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def_readonly("timestamps",
+                      &LogReader::timestamps,
+                      pybind11::call_guard<pybind11::gil_scoped_release>());
 }
 
 }  // namespace robot_interfaces

--- a/include/robot_interfaces/sensors/sensor_logger.hpp
+++ b/include/robot_interfaces/sensors/sensor_logger.hpp
@@ -147,6 +147,7 @@ private:
         {
             try
             {
+                // FIXME: this will block if the sensor has stopped
                 auto timestamp = sensor_data_->observation->timestamp_ms(t);
                 auto observation = (*sensor_data_->observation)[t];
                 buffer_.push_back(std::make_tuple(timestamp, observation));


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

- Release GIL in all Python-bound methods of the sensor interface classes.
- Add a `shutdown()` method to `SensorBackend` so it can be shut down in a way that releases the GIL.


## How I Tested

In the simulation setup of the submission system.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
