### PR TITLE
RobotLogger: Detect if robot data is empty.

### DIFF
--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -16,8 +16,8 @@
 #include <thread>
 
 #include <cereal/archives/binary.hpp>
-#include <cereal/types/vector.hpp>
 #include <cereal/types/tuple.hpp>
+#include <cereal/types/vector.hpp>
 
 #include <robot_interfaces/loggable.hpp>
 #include <robot_interfaces/robot_data.hpp>
@@ -70,7 +70,6 @@ public:
                   "Status must derive from Loggable");
 
     typedef RobotLogEntry<Action, Observation> LogEntry;
-
 
     /**
      * @brief Initialize logger.
@@ -195,8 +194,8 @@ public:
     }
 
     void write_current_buffer_binary(const std::string filename,
-                              long int start_index = 0,
-                              long int end_index = -1)
+                                     long int start_index = 0,
+                                     long int end_index = -1)
     {
         if (is_running_)
         {
@@ -264,7 +263,6 @@ public:
                 t = t_oldest;
             }
         }
-
 
         std::ofstream outfile(filename, std::ios::binary);
         cereal::BinaryOutputArchive archive(outfile);

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -168,6 +168,14 @@ public:
                 "RobotLogger is currently running.  Call stop() first.");
         }
 
+        if (logger_data_->observation->length() == 0)
+        {
+            std::cout
+                << "Warning: RobotLogger buffer is empty.  Nothing to write."
+                << std::endl;
+            return;
+        }
+
         output_file_name_ = filename;
         write_header_to_file();
 
@@ -194,6 +202,14 @@ public:
         {
             throw std::runtime_error(
                 "RobotLogger is currently running.  Call stop() first.");
+        }
+
+        if (logger_data_->observation->length() == 0)
+        {
+            std::cout
+                << "Warning: RobotLogger buffer is empty.  Nothing to write."
+                << std::endl;
+            return;
         }
 
         // set end_index to the current time index if not set or if it is in the


### PR DESCRIPTION
## Description

Detect if the robot data is empty (i.e. robot did not start) in the
`write_current_buffer*` methods as otherwise it will hang there forever.


## How I Tested

With submission system setup on TriFingerPro (only explicitly tested `write_current_buffer_binary`).


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
