### PR TITLE
Make Status::error_message fixed-size

### DIFF
--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -287,7 +287,7 @@ private:
 
                 robot_data_->status->append(status);
 
-                std::cerr << "Error: " << status.error_message
+                std::cerr << "Error: " << status.get_error_message()
                           << "\nRobot is shut down." << std::endl;
 
                 request_shutdown();
@@ -363,7 +363,7 @@ private:
             // if there is an error, shut robot down and stop loop
             if (status.error_status != Status::ErrorStatus::NO_ERROR)
             {
-                std::cerr << "Error: " << status.error_message
+                std::cerr << "Error: " << status.get_error_message()
                           << "\nRobot is shut down." << std::endl;
                 break;
             }

--- a/include/robot_interfaces/robot_frontend.hpp
+++ b/include/robot_interfaces/robot_frontend.hpp
@@ -10,12 +10,10 @@
 
 #include <algorithm>
 #include <cmath>
-
-#include <time_series/time_series.hpp>
-
 #include <robot_interfaces/robot_backend.hpp>
 #include <robot_interfaces/robot_data.hpp>
 #include <robot_interfaces/status.hpp>
+#include <time_series/time_series.hpp>
 
 namespace robot_interfaces
 {
@@ -162,13 +160,13 @@ public:
                     break;
                 case Status::ErrorStatus::DRIVER_ERROR:
                     throw std::runtime_error("Driver Error: " +
-                                             status.error_message);
+                                             status.get_error_message());
                 case Status::ErrorStatus::BACKEND_ERROR:
                     throw std::runtime_error("Backend Error: " +
-                                             status.error_message);
+                                             status.get_error_message());
                 default:
                     throw std::runtime_error("Unknown Error: " +
-                                             status.error_message);
+                                             status.get_error_message());
             }
         }
 

--- a/srcpy/py_generic.cpp
+++ b/srcpy/py_generic.cpp
@@ -32,13 +32,13 @@ PYBIND11_MODULE(py_generic, m)
             "action_repetitions",
             &Status::action_repetitions,
             "int: Number of times the current action has been repeated.")
-        .def_readwrite("error_status",
-                       &Status::error_status,
-                       "ErrorStatus: Current error status.")
-        .def_readwrite("error_message",
-                       &Status::error_message,
-                       "str: Human-readable error message. Only defined if "
-                       "``error_status != NO_ERROR``");
+        .def_readonly("error_status",
+                      &Status::error_status,
+                      "ErrorStatus: Current error status.")
+        .def("set_error",
+             &Status::set_error)
+        .def("get_error_message",
+             &Status::get_error_message);
 
     pybind11::enum_<Status::ErrorStatus>(pystatus, "ErrorStatus")
         .value("NO_ERROR",

--- a/tests/test_robot_backend.cpp
+++ b/tests/test_robot_backend.cpp
@@ -65,5 +65,5 @@ TEST_F(TestRobotBackend, max_number_of_actions)
     auto status = frontend.get_status(t + 1);
     ASSERT_TRUE(status.has_error());
     ASSERT_EQ(Status::ErrorStatus::BACKEND_ERROR, status.error_status);
-    ASSERT_EQ("Maximum number of actions reached.", status.error_message);
+    ASSERT_EQ("Maximum number of actions reached.", status.get_error_message());
 }


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

For use in a multi-process time series, the `Status` objects need to
have fixed size.  Thus replace the variable-size `std::string` with a
fixed size `char` array.  The length is set to 64 characters which is
more than enough for our current error messages (typically < 40 chars).

Since working with plain char-arrays is pretty annoying, make it private
and only access it through methods that convert the message from/to
`std::string`.

## How I Tested

Tested on the robot in a setup similar to the submission system.
The problem could be seen in situations where there is an error reported by the backend.  Without this fix, the frontend crashes when reading the corresponding status object as due to the suddenly added error message it exceeds the expected size.  With this fix, the status object with the error message can be read correctly.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
