### PR TITLE
RobotBackend: Add monitoring methods and pybind request_shutdown()

### DIFF
--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -112,6 +112,12 @@ void create_python_bindings(pybind11::module &m)
              pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("wait_until_terminated",
              &Types::Backend::wait_until_terminated,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("is_running",
+             &Types::Backend::is_running,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("get_termination_reason",
+             &Types::Backend::get_termination_reason,
              pybind11::call_guard<pybind11::gil_scoped_release>());
 
     pybind11::class_<typename Types::Action>(m,

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -107,6 +107,9 @@ void create_python_bindings(pybind11::module &m)
         .def("initialize",
              &Types::Backend::initialize,
              pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("request_shutdown",
+             &Types::Backend::request_shutdown,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("wait_until_first_action",
              &Types::Backend::wait_until_first_action,
              pybind11::call_guard<pybind11::gil_scoped_release>())

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -187,6 +187,21 @@ public:
         return termination_reason_;
     }
 
+    /**
+     * @brief Check if the backend loop is still running.
+     * @return True if the loop is still running.
+     */
+    bool is_running() const
+    {
+        return loop_is_running_;
+    }
+
+    //! @brief Get the termination reason
+    int get_termination_reason() const
+    {
+        return termination_reason_;
+    }
+
 private:
     std::shared_ptr<RobotDriver<Action, Observation>> robot_driver_;
     std::shared_ptr<RobotData<Action, Observation>> robot_data_;


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

- Add methods `is_running()` and `get_termination_reason()` as a non-blocking alternative to `wait_until_terminated()`.
- ￼RobotBackend: Add Python bindings for `request_shutdown()`

With these methods a script running the backend can monitor the backend in a loop and shut it down upon external request.


## How I Tested
By using the methods in a prototype for a new TriFinger submission runner.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
