### PR TITLE
RobotFrontend: Remove deprecated methods

### DIFF
--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -204,44 +204,15 @@ void create_python_bindings(pybind11::module &m)
         .def("get_status",
              &Types::Frontend::get_status,
              pybind11::call_guard<pybind11::gil_scoped_release>())
-        // TODO get_time_stamp_ms is deprecated, remove it some time in the near
-        // future.
-        .def(
-            "get_time_stamp_ms",
-            [](pybind11::object &self, const TimeIndex &t) {
-                auto warnings = pybind11::module::import("warnings");
-                warnings.attr("warn")(
-                    "get_time_stamp_ms() is deprecated, use get_timestamp_ms() "
-                    "instead.");
-                return self.attr("get_timestamp_ms")(t);
-            })
         .def("get_timestamp_ms",
              &Types::Frontend::get_timestamp_ms,
              pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("append_desired_action",
              &Types::Frontend::append_desired_action,
              pybind11::call_guard<pybind11::gil_scoped_release>())
-        // TODO: deprecated, remove in near future
-        .def("wait_until_time_index",
-             [](pybind11::object &self, const TimeIndex &t) {
-                 auto warnings = pybind11::module::import("warnings");
-                 warnings.attr("warn")(
-                     "wait_until_time_index() is deprecated, use "
-                     "wait_until_timeindex() instead.");
-                 return self.attr("wait_until_timeindex")(t);
-             })
         .def("wait_until_timeindex",
              &Types::Frontend::wait_until_timeindex,
              pybind11::call_guard<pybind11::gil_scoped_release>())
-        // TODO: deprecated, remove in near future
-        .def("get_current_time_index",
-             [](pybind11::object &self) {
-                 auto warnings = pybind11::module::import("warnings");
-                 warnings.attr("warn")(
-                     "get_current_time_index() is deprecated, use "
-                     "get_current_timeindex() instead.");
-                 return self.attr("get_current_timeindex")();
-             })
         .def("get_current_timeindex",
              &Types::Frontend::get_current_timeindex,
              pybind11::call_guard<pybind11::gil_scoped_release>());

--- a/include/robot_interfaces/robot_frontend.hpp
+++ b/include/robot_interfaces/robot_frontend.hpp
@@ -98,11 +98,6 @@ public:
         return (*robot_data_->status)[t];
     }
 
-    //! @deprecated Use get_timestamp_ms instead
-    [[deprecated]] TimeStamp get_time_stamp_ms(const TimeIndex &t) const {
-        return get_timestamp_ms(t);
-    }
-
     /**
      * @brief Get the timestamp of time step t.
      *


### PR DESCRIPTION
## Description

Remove some methods from `RobotFrontend` which are deprecated since a while.
For all of them there is an equivalent alternative with only the underscore removed in `time_stamp`/`time_index`, so in case they were still be used somewhere, fixing the code that used it is trivial.

## How I Tested
Compiled the workspace and searched the whole workspace to make sure the removed methods are not mentioned anywhere.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
