### PR TITLE
Check if log file is opened successfully

### DIFF
--- a/include/robot_interfaces/robot_log_reader.hpp
+++ b/include/robot_interfaces/robot_log_reader.hpp
@@ -47,6 +47,11 @@ public:
     void read_file(const std::string &filename)
     {
         std::ifstream infile(filename, std::ios::binary);
+        if (!infile)
+        {
+            throw std::runtime_error("Failed to open file " + filename);
+        }
+
         cereal::BinaryInputArchive archive(infile);
 
         std::uint32_t format_version;

--- a/include/robot_interfaces/sensors/sensor_log_reader.hpp
+++ b/include/robot_interfaces/sensors/sensor_log_reader.hpp
@@ -52,6 +52,11 @@ public:
     void read_file(const std::string &filename)
     {
         std::ifstream infile(filename, std::ios::binary);
+        if (!infile)
+        {
+            throw std::runtime_error("Failed to open file " + filename);
+        }
+
         cereal::BinaryInputArchive archive(infile);
 
         std::uint32_t format_version;


### PR DESCRIPTION
## Description

In both RobotLogReader and SensorLogReader check if the log file is
opened successfully before trying to deserialise it.  This is necessary
to provide a more useful error message in case of failure.


## How I Tested

By passing paths to files that either exist or not and verifying the result.

## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
