### PR TITLE
Use internal buffer in RobotLogger

### DIFF
--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -246,8 +246,9 @@ void create_python_bindings(pybind11::module &m)
 
     pybind11::class_<typename Types::Logger> logger(m, "Logger");
     logger
-        .def(pybind11::init<typename Types::BaseDataPtr, int>(),
+        .def(pybind11::init<typename Types::BaseDataPtr, size_t, int>(),
              pybind11::arg("robot_data"),
+             pybind11::arg("buffer_limit"),
              pybind11::arg("block_size") = 100)
         .def("start",
              &Types::Logger::start,

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -248,22 +248,36 @@ void create_python_bindings(pybind11::module &m)
         .def(pybind11::init<typename Types::BaseDataPtr, int>(),
              pybind11::arg("robot_data"),
              pybind11::arg("block_size") = 100)
-        .def("start", &Types::Logger::start)
-        .def("stop", &Types::Logger::stop)
-        .def("stop_and_save", &Types::Logger::stop_and_save)
-        .def("reset", &Types::Logger::reset)
-        .def("start_continous_writing", &Types::Logger::start_continous_writing)
-        .def("stop_continous_writing", &Types::Logger::stop_continous_writing)
+        .def("start",
+             &Types::Logger::start,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("stop",
+             &Types::Logger::stop,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("stop_and_save",
+             &Types::Logger::stop_and_save,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("reset",
+             &Types::Logger::reset,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("start_continous_writing",
+             &Types::Logger::start_continous_writing,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("stop_continous_writing",
+             &Types::Logger::stop_continous_writing,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("save_current_robot_data",
              &Types::Logger::save_current_robot_data,
              pybind11::arg("filename"),
              pybind11::arg("start_index") = 0,
-             pybind11::arg("end_index") = -1)
+             pybind11::arg("end_index") = -1,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("save_current_robot_data_binary",
              &Types::Logger::save_current_robot_data_binary,
              pybind11::arg("filename"),
              pybind11::arg("start_index") = 0,
-             pybind11::arg("end_index") = -1)
+             pybind11::arg("end_index") = -1,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
         // raise warining when using deprecated method
         .def("write_current_buffer",
              [](pybind11::object &self,

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -254,13 +254,46 @@ void create_python_bindings(pybind11::module &m)
         .def("reset", &Types::Logger::stop)
         .def("start_continous_writing", &Types::Logger::start)
         .def("stop_continous_writing", &Types::Logger::stop)
+        .def("save_current_robot_data",
+             &Types::Logger::save_current_robot_data,
+             pybind11::arg("filename"),
+             pybind11::arg("start_index") = 0,
+             pybind11::arg("end_index") = -1)
+        .def("save_current_robot_data_binary",
+             &Types::Logger::save_current_robot_data_binary,
+             pybind11::arg("filename"),
+             pybind11::arg("start_index") = 0,
+             pybind11::arg("end_index") = -1)
+        // raise warining when using deprecated method
         .def("write_current_buffer",
-             &Types::Logger::write_current_buffer,
+             [](pybind11::object &self,
+                const std::string &filename,
+                long int start_index,
+                long int end_index) {
+                 auto warnings = pybind11::module::import("warnings");
+                 warnings.attr("warn")(
+                     "write_current_buffer() is deprecated, use "
+                     "save_current_robot_data() "
+                     "instead.");
+                 return self.attr("save_current_robot_data")(
+                     filename, start_index, end_index);
+             },
              pybind11::arg("filename"),
              pybind11::arg("start_index") = 0,
              pybind11::arg("end_index") = -1)
         .def("write_current_buffer_binary",
-             &Types::Logger::write_current_buffer_binary,
+             [](pybind11::object &self,
+                const std::string &filename,
+                long int start_index,
+                long int end_index) {
+                 auto warnings = pybind11::module::import("warnings");
+                 warnings.attr("warn")(
+                     "write_current_buffer_binary() is deprecated, use "
+                     "save_current_robot_data_binary() "
+                     "instead.");
+                 return self.attr("save_current_robot_data_binary")(
+                     filename, start_index, end_index);
+             },
              pybind11::arg("filename"),
              pybind11::arg("start_index") = 0,
              pybind11::arg("end_index") = -1);

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -250,6 +250,10 @@ void create_python_bindings(pybind11::module &m)
              pybind11::arg("block_size") = 100)
         .def("start", &Types::Logger::start)
         .def("stop", &Types::Logger::stop)
+        .def("stop_and_save", &Types::Logger::stop)
+        .def("reset", &Types::Logger::stop)
+        .def("start_continous_writing", &Types::Logger::start)
+        .def("stop_continous_writing", &Types::Logger::stop)
         .def("write_current_buffer",
              &Types::Logger::write_current_buffer,
              pybind11::arg("filename"),

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -250,10 +250,10 @@ void create_python_bindings(pybind11::module &m)
              pybind11::arg("block_size") = 100)
         .def("start", &Types::Logger::start)
         .def("stop", &Types::Logger::stop)
-        .def("stop_and_save", &Types::Logger::stop)
-        .def("reset", &Types::Logger::stop)
-        .def("start_continous_writing", &Types::Logger::start)
-        .def("stop_continous_writing", &Types::Logger::stop)
+        .def("stop_and_save", &Types::Logger::stop_and_save)
+        .def("reset", &Types::Logger::reset)
+        .def("start_continous_writing", &Types::Logger::start_continous_writing)
+        .def("stop_continous_writing", &Types::Logger::stop_continous_writing)
         .def("save_current_robot_data",
              &Types::Logger::save_current_robot_data,
              pybind11::arg("filename"),

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -244,7 +244,8 @@ void create_python_bindings(pybind11::module &m)
         .def_readwrite("desired_action", &Types::LogEntry::desired_action)
         .def_readwrite("applied_action", &Types::LogEntry::applied_action);
 
-    pybind11::class_<typename Types::Logger>(m, "Logger")
+    pybind11::class_<typename Types::Logger> logger(m, "Logger");
+    logger
         .def(pybind11::init<typename Types::BaseDataPtr, int>(),
              pybind11::arg("robot_data"),
              pybind11::arg("block_size") = 100)
@@ -311,6 +312,11 @@ void create_python_bindings(pybind11::module &m)
              pybind11::arg("filename"),
              pybind11::arg("start_index") = 0,
              pybind11::arg("end_index") = -1);
+
+    pybind11::enum_<typename Types::Logger::Format>(logger, "Format")
+        .value("BINARY", Types::Logger::Format::BINARY)
+        .value("CSV", Types::Logger::Format::CSV)
+        .value("CSV_GZIP", Types::Logger::Format::CSV_GZIP);
 
     pybind11::class_<typename Types::BinaryLogReader,
                      std::shared_ptr<typename Types::BinaryLogReader>>(

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -12,6 +12,7 @@
 #include <chrono>
 #include <fstream>
 #include <iostream>
+#include <iterator>
 #include <limits>
 #include <thread>
 
@@ -36,24 +37,29 @@ namespace robot_interfaces
  * line per time step with values separated by spaces.  This format can easily
  * be read e.g. with NumPy or Pandas.
  *
- * There are two different ways of using the logger:
+ * There are different ways of using the logger:
  *
- *  1. Write all the data from the time series to the file in one function call.
- *     Use this if the time series buffer is big enough to cover the whole time
- *     span that you want to log.  This way all the data is written to the file
- *     in the end, when the robot is not moving anymore.  This way it will not
- *     interfere with the running robot but there is the risk of losing all data
- *     in case the software crashes before writing the log.
- *     Use the method `write_current_buffer()` for this.
- *  2. Run the logger in the background and write blocks of data to the log file
- *     while the robot is running.  This has the advantage that arbitrary time
- *     spans can be logged independent of the buffer size of the time series.
- *     Further in case of a software crash not all data will be lost but only
- *     the data since the last block was written.  However, it has the huge
- *     disadvantage that writing to the file may cause delays in the real-time
- *     critical robot code, thus causing the robot to shut down if timing
- *     constraints are violated.
- *     Use the `start()` and `stop()` methods for this.
+ *  1. Using @ref start() and @ref stop_and_save():  The logger runs a thread in
+ *     which it copies all data to an internal buffer while the robot is
+ *     running.  When calling @ref stop_and_save() the content of the buffer is
+ *     stored to a file (either binary or text).
+ *     This is the recommended method for most applications.
+ *  2. Using @ref write_current_buffer() or @ref write_current_buffer_binary():
+ *     Call this to log data that is currently held in the robot data time
+ *     series.  For this method, the logger doesn't use an own buffer, so no
+ *     data is copied while the robot is running.  However, the possible time
+ *     span for logging is limited by the size of the robot data time series.
+ *  3. Using @ref start_continous_writing() and @ref stop_continous_writing():
+ *     Run the logger in the background and write blocks of data directly to the
+ *     log file while the robot is running (i.e. no buffering in memory is
+ *     needed).  This has the advantage that arbitrary time spans can be logged
+ *     independent of the buffer size of the time series.  Further in case of a
+ *     software crash not all data will be lost but only the data since the last
+ *     block was written.  However, the permanent writing to a file puts some
+ *     load on the system and may cause delays in the real-time critical robot
+ *     code, thus causing the robot to shut down if timing constraints are
+ *     violated.
+ *     This method only supports uncompressed CSV as logfile format.
  *
  * @tparam Action  Type of the robot action.  Must derive from Loggable.
  * @tparam Observation  Type of the robot observation.  Must derive from
@@ -73,6 +79,14 @@ public:
 
     typedef RobotLogEntry<Action, Observation> LogEntry;
 
+    //! @brief Enumeration of possible log file formats.
+    enum class Format
+    {
+        BINARY,
+        CSV,
+        CSV_GZIP
+    };
+
     /**
      * @brief Initialize logger.
      *
@@ -83,18 +97,93 @@ public:
     RobotLogger(
         std::shared_ptr<robot_interfaces::RobotData<Action, Observation>>
             robot_data,
+        size_t buffer_limit,
         int block_size = 100)
         : logger_data_(robot_data),
+          buffer_limit_(buffer_limit),
           block_size_(block_size),
           stop_was_called_(false),
-          is_running_(false)
+          enabled_(false)
     {
+        // directly reserve the memory for the full buffer so it does not need
+        // to move data around during run time
+        buffer_.reserve(buffer_limit);
     }
+
+    // reinstate the implicit move constructor
+    // See https://stackoverflow.com/a/27474070
+    RobotLogger(RobotLogger &&) = default;
 
     virtual ~RobotLogger()
     {
         stop();
     }
+
+    // ### Methods for logging with the internal buffer
+
+    /**
+     * @brief Start logging using an internal buffer.
+     *
+     * The buffer is limited by the `buffer_limit` argument of the constructor.
+     * If the limit is reached, the logger stops automatically.
+     *
+     * If the logger is already running, this is a noop.
+     */
+    void start()
+    {
+        if (!enabled_)
+        {
+            enabled_ = true;
+            thread_ = std::thread(
+                &RobotLogger<Action, Observation>::buffer_loop, this);
+        }
+    }
+
+    /**
+     * @brief Stop logging.
+     *
+     * If the logger is already stopped, this is a noop.
+     */
+    void stop()
+    {
+        enabled_ = false;
+        if (thread_.joinable())
+        {
+            thread_.join();
+        }
+    }
+
+    //! @brief Clear the log buffer.
+    void reset()
+    {
+        buffer_.clear();
+    }
+
+    /**
+     * @brief Stop logging and save logged messages to a file.
+     *
+     * @param filename Path to the output file.  Existing files will be
+     *     overwritten.
+     */
+    void stop_and_save(const std::string &filename, Format log_format)
+    {
+        stop();
+
+        switch (log_format)
+        {
+            case Format::BINARY:
+                save_buffer_binary(filename);
+                break;
+            case Format::CSV:
+                save_buffer_text(filename, false);
+                break;
+            case Format::CSV_GZIP:
+                save_buffer_text(filename, true);
+                break;
+        }
+    }
+
+    // ### Methods for logging by writing to file continuously
 
     /**
      * @brief Start a thread to continuously log to file in the background.
@@ -103,7 +192,7 @@ public:
      * @param filename The name of the log file.  Existing files will be
      *     overwritten!
      */
-    void start(const std::string &filename)
+    void start_continous_writing(const std::string &filename)
     {
         stop_was_called_ = false;
         output_file_name_ = filename;
@@ -111,16 +200,16 @@ public:
     }
 
     /**
-     * @brief Stop logging that was started with `start()` previously.
+     * @brief Stop logging that was started with `start_continous_writing()`.
      *
      * Does nothing if logger is not currently running.
      */
-    void stop()
+    void stop_continous_writing()
     {
         // This is a bit complicated:  In any case, join the thread if it is
         // joinable.  However, only write the remaining data to file if the
         // logging thread is actually running at the moment stop() is called.
-        bool still_running = is_running_;
+        bool still_running = enabled_;
 
         stop_was_called_ = true;
         if (thread_.joinable())
@@ -133,6 +222,10 @@ public:
             append_robot_data_to_file(output_file_name_, index_, block_size_);
         }
     }
+
+    // ### Methods for directly logging the content of the time series
+
+    // TODO rename "write_current_buffer" methods?
 
     /**
      * @brief Write current content of robot data to log file.
@@ -163,7 +256,7 @@ public:
                               long int start_index = 0,
                               long int end_index = -1)
     {
-        if (is_running_)
+        if (enabled_)
         {
             throw std::runtime_error(
                 "RobotLogger is currently running.  Call stop() first.");
@@ -199,7 +292,7 @@ public:
                                      long int start_index = 0,
                                      long int end_index = -1)
     {
-        if (is_running_)
+        if (enabled_)
         {
             throw std::runtime_error(
                 "RobotLogger is currently running.  Call stop() first.");
@@ -284,11 +377,14 @@ private:
     std::shared_ptr<robot_interfaces::RobotData<Action, Observation>>
         logger_data_;
 
+    std::vector<LogEntry> buffer_;
+    size_t buffer_limit_;
+
     int block_size_;
     long int index_;
 
     std::atomic<bool> stop_was_called_;
-    std::atomic<bool> is_running_;
+    std::atomic<bool> enabled_;
 
     std::string output_file_name_;
 
@@ -298,7 +394,7 @@ private:
      *
      * @return header The title of the log file.
      */
-    std::vector<std::string> construct_header()
+    std::vector<std::string> construct_header() const
     {
         Action action;
         Observation observation;
@@ -342,7 +438,7 @@ private:
         const std::string &identifier,
         const std::vector<std::string> &field_name,
         const std::vector<std::vector<double>> &field_data,
-        std::vector<std::string> &header)
+        std::vector<std::string> &header) const
     {
         for (size_t i = 0; i < field_name.size(); i++)
         {
@@ -364,20 +460,26 @@ private:
     }
 
     /**
-     * @brief Write the header to the log file.  This overwrites existing files!
+     * @brief Write CSV header to the log file.  This overwrites existing files!
      */
-    void write_header_to_file(const std::string &filename)
+    void write_header_to_file(const std::string &filename) const
     {
-        std::ofstream output_file;
-        output_file.open(filename);
-        std::ostream_iterator<std::string> string_iterator(output_file, " ");
+        std::ofstream output_file(filename);
+        write_header_to_stream(output_file);
+        output_file.close();
+    }
+
+    /**
+     * @brief Write CSV header to the output stream.
+     */
+    void write_header_to_stream(std::ostream &output) const
+    {
+        std::ostream_iterator<std::string> string_iterator(output, " ");
 
         std::vector<std::string> header = construct_header();
 
         std::copy(header.begin(), header.end(), string_iterator);
-        output_file << std::endl;
-
-        output_file.close();
+        output << std::endl;
     }
 
     /**
@@ -439,6 +541,30 @@ private:
     }
 
     /**
+     * @brief Appends the logger buffer as plain text (CSV) to an output stream.
+     *
+     * @param output_stream  Output stream to which the log is written.
+     */
+    void append_logger_buffer(std::ostream &output_stream) const
+    {
+        // output_file.open(filename, std::ios_base::app);
+        output_stream.precision(27);
+
+        for (LogEntry entry : buffer_)
+        {
+            output_stream << entry.timeindex << " " << entry.timestamp << " ";
+            append_field_data_to_file(entry.status.get_data(), output_stream);
+            append_field_data_to_file(entry.observation.get_data(),
+                                      output_stream);
+            append_field_data_to_file(entry.applied_action.get_data(),
+                                      output_stream);
+            append_field_data_to_file(entry.desired_action.get_data(),
+                                      output_stream);
+            output_stream << std::endl;
+        }
+    }
+
+    /**
      * @brief Appends the data corresponding to
      * every field at the same time index to the log file.
      *
@@ -446,7 +572,7 @@ private:
      */
     void append_field_data_to_file(
         const std::vector<std::vector<double>> &field_data,
-        std::ostream &output_stream)
+        std::ostream &output_stream) const
     {
         std::ostream_iterator<double> double_iterator(output_stream, " ");
 
@@ -457,6 +583,41 @@ private:
     }
 
     /**
+     * @brief Save content of the internal buffer to a binary file.
+     *
+     * @param filename  Path/name of the output file.
+     */
+    void save_buffer_binary(const std::string &filename) const
+    {
+        std::ofstream outfile(filename, std::ios::binary);
+
+        auto outfile_compressed = serialization_utils::gzip_ostream(outfile);
+        cereal::BinaryOutputArchive archive(*outfile_compressed);
+
+        // add version information to the output file (this can be used while
+        // loading when the data format changes
+        const std::uint32_t format_version = 2;
+
+        archive(format_version, buffer_);
+    }
+
+    /**
+     * @brief Save content of the internal buffer to a CSV file.
+     *
+     * @param filename  Path/name of the output file
+     * @param use_gzip  If true, the output file is gzip-compressed.
+     */
+    void save_buffer_text(const std::string &filename,
+                          bool use_gzip = false) const
+    {
+        std::ofstream output_file(filename);
+        auto output = serialization_utils::gzip_ostream(output_file, use_gzip);
+
+        write_header_to_stream(*output);
+        append_logger_buffer(*output);
+    }
+
+    /**
      * @brief Writes everything to the log file.
      *
      * It dumps all the data corresponding to block_size_ number of time indices
@@ -464,7 +625,7 @@ private:
      */
     void loop()
     {
-        is_running_ = true;
+        enabled_ = true;
 
         write_header_to_file(output_file_name_);
 
@@ -504,7 +665,63 @@ private:
             }
         }
 
-        is_running_ = false;
+        enabled_ = false;
+    }
+
+    //! Get observations from logger_data_ and add them to the buffer.
+    void buffer_loop()
+    {
+        auto t = logger_data_->observation->oldest_timeindex();
+
+        while (enabled_)
+        {
+            // wait for the next time step but check if the logger was stopped
+            // from time to time
+            constexpr double wait_timeout_s = 0.2;
+            while (!logger_data_->applied_action->wait_for_timeindex(
+                t, wait_timeout_s))
+            {
+                if (!enabled_)
+                {
+                    return;
+                }
+            }
+
+            try
+            {
+                LogEntry entry;
+
+                entry.timeindex = t;
+                entry.applied_action = (*logger_data_->applied_action)[t];
+                entry.desired_action = (*logger_data_->desired_action)[t];
+                entry.observation = (*logger_data_->observation)[t];
+                entry.status = (*logger_data_->status)[t];
+                entry.timestamp = logger_data_->observation->timestamp_s(t);
+
+                buffer_.push_back(entry);
+                t++;
+            }
+            catch (const std::invalid_argument &e)
+            {
+                auto t_oldest = logger_data_->observation->oldest_timeindex();
+                auto diff = t_oldest - t;
+
+                std::cerr << "ERROR: While logging time step " << t << ": "
+                          << e.what() << "\nSkip " << diff << " observation(s)."
+                          << std::endl;
+
+                t = t_oldest;
+            }
+
+            // Stop logging if buffer limit is reached
+            if (buffer_.size() >= buffer_limit_)
+            {
+                std::cerr << "WARNING: SensorLogger buffer limit is reached.  "
+                             "Stop logging."
+                          << std::endl;
+                enabled_ = false;
+            }
+        }
     }
 };
 

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -50,6 +50,7 @@ namespace robot_interfaces
  *     data is copied while the robot is running.  However, the possible time
  *     span for logging is limited by the size of the robot data time series.
  *  3. Using @ref start_continous_writing() and @ref stop_continous_writing():
+ *     Deprecated!
  *     Run the logger in the background and write blocks of data directly to the
  *     log file while the robot is running (i.e. no buffering in memory is
  *     needed).  This has the advantage that arbitrary time spans can be logged
@@ -188,10 +189,12 @@ public:
     /**
      * @brief Start a thread to continuously log to file in the background.
      *
-     * @see stop()
+     * @deprecated
+     * @see stop_continous_writing()
      * @param filename The name of the log file.  Existing files will be
      *     overwritten!
      */
+    [[deprecated]]
     void start_continous_writing(const std::string &filename)
     {
         stop_was_called_ = false;
@@ -203,7 +206,10 @@ public:
      * @brief Stop logging that was started with `start_continous_writing()`.
      *
      * Does nothing if logger is not currently running.
+     *
+     * @deprecated
      */
+    [[deprecated]]
     void stop_continous_writing()
     {
         // This is a bit complicated:  In any case, join the thread if it is

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -225,10 +225,8 @@ public:
 
     // ### Methods for directly logging the content of the time series
 
-    // TODO rename "write_current_buffer" methods?
-
     /**
-     * @brief Write current content of robot data to log file.
+     * @brief Write current content of robot data to CSV log file.
      *
      * Write data of the time steps `[start_index, end_index)` to a log file.
      * This assumes that the specified range is completely included in the
@@ -252,9 +250,9 @@ public:
      *     stopped by calling `stop()` before `write_current_buffer()` can be
      *     used.
      */
-    void write_current_buffer(const std::string filename,
-                              long int start_index = 0,
-                              long int end_index = -1)
+    void save_current_robot_data(const std::string &filename,
+                                 long int start_index = 0,
+                                 long int end_index = -1)
     {
         if (enabled_)
         {
@@ -288,9 +286,10 @@ public:
             filename, start_index, end_index - start_index);
     }
 
-    void write_current_buffer_binary(const std::string filename,
-                                     long int start_index = 0,
-                                     long int end_index = -1)
+    //! @brief Like save_current_robot_data but using binary file format.
+    void save_current_robot_data_binary(const std::string &filename,
+                                        long int start_index = 0,
+                                        long int end_index = -1)
     {
         if (enabled_)
         {
@@ -369,6 +368,22 @@ public:
         const std::uint32_t format_version = 2;
 
         archive(format_version, log_data);
+    }
+
+    [[deprecated("Renamed to write_current_robot_data")]]
+    void write_current_buffer(const std::string &filename,
+                              long int start_index = 0,
+                              long int end_index = -1)
+    {
+        save_current_robot_data(filename, start_index, end_index);
+    }
+
+    [[deprecated("Renamed to write_current_robot_data_binary")]]
+    void write_current_buffer_binary(const std::string &filename,
+                                     long int start_index = 0,
+                                     long int end_index = -1)
+    {
+        save_current_robot_data_binary(filename, start_index, end_index);
     }
 
 private:

--- a/include/robot_interfaces/sensors/sensor_logger.hpp
+++ b/include/robot_interfaces/sensors/sensor_logger.hpp
@@ -149,6 +149,18 @@ private:
 
         while (enabled_)
         {
+            // wait for the next time step but check if the logger was stopped
+            // from time to time
+            constexpr double wait_timeout_s = 0.2;
+            while (!sensor_data_->observation->wait_for_timeindex(
+                t, wait_timeout_s))
+            {
+                if (!enabled_)
+                {
+                    return;
+                }
+            }
+
             try
             {
                 // FIXME: this will block if the sensor has stopped

--- a/tests/test_robot_logger.cpp
+++ b/tests/test_robot_logger.cpp
@@ -134,7 +134,7 @@ protected:
     }
 };
 
-TEST_F(TestRobotLogger, write_current_buffer)
+TEST_F(TestRobotLogger, save_current_robot_data)
 {
     Logger logger(data, 0);
 
@@ -156,12 +156,12 @@ TEST_F(TestRobotLogger, write_current_buffer)
     // wait a moment to give the logger time to catch up
     std::this_thread::sleep_for(std::chrono::milliseconds(50));
 
-    logger.write_current_buffer(logfile);
+    logger.save_current_robot_data(logfile);
 
     check_csv_log(logfile, 0, max_number_of_actions, false);
 }
 
-TEST_F(TestRobotLogger, write_current_buffer_binary)
+TEST_F(TestRobotLogger, save_current_robot_data_binary)
 {
     Logger logger(data, 0);
 
@@ -178,7 +178,7 @@ TEST_F(TestRobotLogger, write_current_buffer_binary)
         t = frontend->append_desired_action(action);
         frontend->wait_until_timeindex(t);
     }
-    logger.write_current_buffer_binary(logfile);
+    logger.save_current_robot_data_binary(logfile);
 
     // read the log for verification
     BinaryLogReader log(logfile);

--- a/tests/test_robot_logger.cpp
+++ b/tests/test_robot_logger.cpp
@@ -155,7 +155,7 @@ TEST_F(TestRobotLogger, save_current_robot_data)
 
     // TODO: Why is the sleep needed here?
     // wait a moment to give the logger time to catch up
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     logger.save_current_robot_data(logfile);
 
@@ -217,7 +217,7 @@ TEST_F(TestRobotLogger, start_stop_binary)
     }
 
     // wait a moment to give the logger time to catch up
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     logger.stop_and_save(logfile, Logger::Format::BINARY);
 
@@ -255,7 +255,7 @@ TEST_F(TestRobotLogger, start_stop_csv)
     }
 
     // wait a moment to give the logger time to catch up
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     logger.stop_and_save(logfile, Logger::Format::CSV);
 
@@ -286,7 +286,7 @@ TEST_F(TestRobotLogger, start_stop_csv_gzip)
     }
 
     // wait a moment to give the logger time to catch up
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     logger.stop_and_save(logfile, Logger::Format::CSV_GZIP);
 
@@ -319,7 +319,7 @@ TEST_F(TestRobotLogger, start_stop_continuous)
     }
 
     // wait a moment to give the logger time to catch up
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     logger.stop_continous_writing();
 

--- a/tests/test_robot_logger.cpp
+++ b/tests/test_robot_logger.cpp
@@ -149,7 +149,8 @@ TEST_F(TestRobotLogger, save_current_robot_data)
     {
         action.values[0] = i;
         t = frontend->append_desired_action(action);
-        frontend->wait_until_timeindex(t);
+        // wait for applied action to ensure all data of that time step is there
+        frontend->get_applied_action(t);
     }
 
     // TODO: Why is the sleep needed here?
@@ -176,7 +177,8 @@ TEST_F(TestRobotLogger, save_current_robot_data_binary)
     {
         action.values[0] = i;
         t = frontend->append_desired_action(action);
-        frontend->wait_until_timeindex(t);
+        // wait for applied action to ensure all data of that time step is there
+        frontend->get_applied_action(t);
     }
     logger.save_current_robot_data_binary(logfile);
 
@@ -210,7 +212,8 @@ TEST_F(TestRobotLogger, start_stop_binary)
     {
         action.values[0] = i;
         t = frontend->append_desired_action(action);
-        frontend->wait_until_timeindex(t);
+        // wait for applied action to ensure all data of that time step is there
+        frontend->get_applied_action(t);
     }
 
     // wait a moment to give the logger time to catch up
@@ -247,7 +250,8 @@ TEST_F(TestRobotLogger, start_stop_csv)
     {
         action.values[0] = i;
         t = frontend->append_desired_action(action);
-        frontend->wait_until_timeindex(t);
+        // wait for applied action to ensure all data of that time step is there
+        frontend->get_applied_action(t);
     }
 
     // wait a moment to give the logger time to catch up
@@ -277,7 +281,8 @@ TEST_F(TestRobotLogger, start_stop_csv_gzip)
     {
         action.values[0] = i;
         t = frontend->append_desired_action(action);
-        frontend->wait_until_timeindex(t);
+        // wait for applied action to ensure all data of that time step is there
+        frontend->get_applied_action(t);
     }
 
     // wait a moment to give the logger time to catch up
@@ -309,7 +314,8 @@ TEST_F(TestRobotLogger, start_stop_continuous)
     {
         action.values[0] = i;
         t = frontend->append_desired_action(action);
-        frontend->wait_until_timeindex(t);
+        // wait for applied action to ensure all data of that time step is there
+        frontend->get_applied_action(t);
     }
 
     // wait a moment to give the logger time to catch up


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Refactor the `RobotLogger` and add a logging mode that uses an internal buffer (same as in SensorLogger).  This should resolve some issues we had in the past where some time steps were missing in the log because they where not in the robot data time series anymore.

This new logging method supports writing to either binary, CSV or gzipped CSV files.

The old `start()`/`stop()` methods (used for continuous writing to file) have been renamed to `start|stop_continuous_writing()`.  Further this methods are marked deprecated as I plan to remove them soon, to not make the logger too bloated (this logging method is anyway not used at the moment).

To avoid confusion with the internal buffer, rename the `write_current_buffer*` methods to `save_current_robot_data*`.  The old names are kept as aliases for now but are marked deprecated.


### Other Changes
- Use applied_action in RobotFrontend::wait_for_timeindex.  The observation is the first time series to be filled by the backend, so when waiting only for this, it is not guaranteed that the other time series have already been filled.  To ensure this, use the applied_action time series instead, which is the last one to be filled.
- Avoid blocking in SensorLogger in case the backend has stopped.

## How I Tested

By running the unit tests.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
