### PR TITLE
Refactor Gzip Stream Wrappers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,9 +12,6 @@ cmake_minimum_required(VERSION 3.10.2)
 project(robot_interfaces)
 
 # Using C++17.
-if(NOT CMAKE_C_STANDARD)
-  set(CMAKE_C_STANDARD 99)
-endif()
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 17)
 endif()
@@ -33,8 +30,6 @@ find_package(signal_handler REQUIRED)
 find_package(serialization_utils REQUIRED)
 find_package(Threads)
 find_package(rt)
-
-include(cmake/find_boost_components.cmake)
 
 # export the dependencies
 ament_export_dependencies(pybind11 Eigen3 Boost real_time_tools time_series
@@ -62,6 +57,7 @@ target_link_libraries(${PROJECT_NAME} INTERFACE real_time_tools::real_time_tools
 target_link_libraries(${PROJECT_NAME} INTERFACE time_series::time_series)
 target_link_libraries(${PROJECT_NAME} INTERFACE signal_handler::signal_handler)
 target_link_libraries(${PROJECT_NAME} INTERFACE serialization_utils::serialization_utils)
+target_link_libraries(${PROJECT_NAME} INTERFACE serialization_utils::gzip_iostream)
 target_link_libraries(${PROJECT_NAME} INTERFACE Threads::Threads)
 target_link_libraries(${PROJECT_NAME} INTERFACE pybind11::embed)
 target_link_libraries(${PROJECT_NAME} INTERFACE Boost::iostreams)
@@ -130,6 +126,4 @@ install(
 #
 # Export the package as ament
 #
-ament_package(
-    CONFIG_EXTRAS cmake/find_boost_components.cmake
-)
+ament_package()

--- a/cmake/find_boost_components.cmake
+++ b/cmake/find_boost_components.cmake
@@ -1,4 +1,0 @@
-# Put this in a separate file, so it can be experted via CONFIG_EXTRAS.
-# This is needed because ament doesn't support exporting components (see
-# https://answers.ros.org/question/331089/ament_export_dependenciesboost-not-working/?answer=332460#post-id-332460)
-find_package(Boost REQUIRED COMPONENTS iostreams)

--- a/include/robot_interfaces/robot_log_reader.hpp
+++ b/include/robot_interfaces/robot_log_reader.hpp
@@ -9,12 +9,11 @@
 #include <fstream>
 #include <vector>
 
-#include <boost/iostreams/filtering_stream.hpp>
-#include <boost/iostreams/filter/gzip.hpp>
-
 #include <cereal/archives/binary.hpp>
 #include <cereal/types/tuple.hpp>
 #include <cereal/types/vector.hpp>
+
+#include <serialization_utils/gzip_iostream.hpp>
 
 #include <robot_interfaces/robot_log_entry.hpp>
 
@@ -55,12 +54,8 @@ public:
             throw std::runtime_error("Failed to open file " + filename);
         }
 
-        // wrap the file stream with a gzip decompressor
-        boost::iostreams::filtering_istream infile_compressed;
-        infile_compressed.push(boost::iostreams::gzip_decompressor()); 
-        infile_compressed.push(infile);
-
-        cereal::BinaryInputArchive archive(infile_compressed);
+        auto infile_compressed = serialization_utils::gzip_istream(infile);
+        cereal::BinaryInputArchive archive(*infile_compressed);
 
         std::uint32_t format_version;
         archive(format_version);

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -15,12 +15,11 @@
 #include <limits>
 #include <thread>
 
-#include <boost/iostreams/filter/gzip.hpp>
-#include <boost/iostreams/filtering_stream.hpp>
-
 #include <cereal/archives/binary.hpp>
 #include <cereal/types/tuple.hpp>
 #include <cereal/types/vector.hpp>
+
+#include <serialization_utils/gzip_iostream.hpp>
 
 #include <robot_interfaces/loggable.hpp>
 #include <robot_interfaces/robot_data.hpp>
@@ -269,12 +268,8 @@ public:
 
         std::ofstream outfile(filename, std::ios::binary);
 
-        // wrap the out stream with a gzip compressor
-        boost::iostreams::filtering_ostream outfile_compressed;
-        outfile_compressed.push(boost::iostreams::gzip_compressor());
-        outfile_compressed.push(outfile);
-
-        cereal::BinaryOutputArchive archive(outfile_compressed);
+        auto outfile_compressed = serialization_utils::gzip_ostream(outfile);
+        cereal::BinaryOutputArchive archive(*outfile_compressed);
 
         // add version information to the output file (this can be used while
         // loading when the data format changes

--- a/include/robot_interfaces/sensors/sensor_log_reader.hpp
+++ b/include/robot_interfaces/sensors/sensor_log_reader.hpp
@@ -9,11 +9,10 @@
 #include <fstream>
 #include <vector>
 
-#include <boost/iostreams/filter/gzip.hpp>
-#include <boost/iostreams/filtering_stream.hpp>
-
 #include <cereal/archives/binary.hpp>
 #include <cereal/types/vector.hpp>
+
+#include <serialization_utils/gzip_iostream.hpp>
 
 namespace robot_interfaces
 {
@@ -55,17 +54,14 @@ public:
     void read_file(const std::string &filename)
     {
         std::ifstream infile(filename, std::ios::binary);
+
         if (!infile)
         {
             throw std::runtime_error("Failed to open file " + filename);
         }
 
-        // wrap the file stream with a gzip decompressor
-        boost::iostreams::filtering_istream infile_compressed;
-        infile_compressed.push(boost::iostreams::gzip_decompressor()); 
-        infile_compressed.push(infile);
-
-        cereal::BinaryInputArchive archive(infile_compressed);
+        auto infile_compressed = serialization_utils::gzip_istream(infile);
+        cereal::BinaryInputArchive archive(*infile_compressed);
 
         std::uint32_t format_version;
         archive(format_version);

--- a/include/robot_interfaces/sensors/sensor_logger.hpp
+++ b/include/robot_interfaces/sensors/sensor_logger.hpp
@@ -14,12 +14,11 @@
 #include <thread>
 #include <vector>
 
-#include <boost/iostreams/filter/gzip.hpp>
-#include <boost/iostreams/filtering_stream.hpp>
-
 #include <cereal/archives/binary.hpp>
 #include <cereal/types/tuple.hpp>
 #include <cereal/types/vector.hpp>
+
+#include <serialization_utils/gzip_iostream.hpp>
 
 #include "sensor_data.hpp"
 
@@ -126,12 +125,8 @@ public:
 
         std::ofstream outfile(filename, std::ios::binary);
 
-        // wrap the out stream with a gzip compressor
-        boost::iostreams::filtering_ostream outfile_compressed;
-        outfile_compressed.push(boost::iostreams::gzip_compressor());
-        outfile_compressed.push(outfile);
-
-        cereal::BinaryOutputArchive archive(outfile_compressed);
+        auto outfile_compressed = serialization_utils::gzip_ostream(outfile);
+        cereal::BinaryOutputArchive archive(*outfile_compressed);
 
         // add version information to the output file (this can be used while
         // loading when the data format changes


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

- Move the code for wrapping streams with gzip (de-)compression to a separate library to avoid code duplication.
- For the istream identify if the input is actually gzip compressed by checking the first two bytes for the magic number.  This allows reading both compressed and uncompressed logs and thus provides backward compatibility.


## How I Tested

By reading both compressed and uncompressed logfiles and by running the unit tests.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
