### PR TITLE
Add `convert_old_robot_log`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,11 @@ ament_export_targets(export_${PROJECT_NAME} HAS_LIBRARY_TARGET)
 list(APPEND all_targets ${PROJECT_NAME})
 list(APPEND all_target_exports export_${PROJECT_NAME})
 
+
+add_executable(convert_old_robot_log src/convert_old_robot_log.cpp)
+target_link_libraries(convert_old_robot_log ${PROJECT_NAME})
+list(APPEND all_targets convert_old_robot_log)
+
 #
 # manage the demos.
 #

--- a/include/robot_interfaces/robot_log_entry.hpp
+++ b/include/robot_interfaces/robot_log_entry.hpp
@@ -15,12 +15,12 @@ namespace robot_interfaces
  *
  * Contains all the robot data of one time step.
  */
-template <typename Action, typename Observation>
+template <typename Action, typename Observation, typename Status_t = Status>
 struct RobotLogEntry
 {
     time_series::Index timeindex;
     time_series::Timestamp timestamp;
-    Status status;
+    Status_t status;
     Observation observation;
     Action desired_action;
     Action applied_action;

--- a/include/robot_interfaces/robot_log_reader.hpp
+++ b/include/robot_interfaces/robot_log_reader.hpp
@@ -87,7 +87,7 @@ public:
         {
             throw std::runtime_error("Failed to open file " + filename);
         }
-        auto outfile_compressed = gzip_ostream(outfile);
+        auto outfile_compressed = serialization_utils::gzip_ostream(outfile);
         cereal::BinaryOutputArchive archive(*outfile_compressed);
 
         archive(FORMAT_VERSION, data);

--- a/include/robot_interfaces/robot_log_reader.hpp
+++ b/include/robot_interfaces/robot_log_reader.hpp
@@ -16,6 +16,7 @@
 #include <serialization_utils/gzip_iostream.hpp>
 
 #include <robot_interfaces/robot_log_entry.hpp>
+#include <robot_interfaces/status.hpp>
 
 namespace robot_interfaces
 {
@@ -25,11 +26,11 @@ namespace robot_interfaces
  * The data is read from the specified file and stored to the `data` member
  * where it can be accessed.
  */
-template <typename Action, typename Observation>
+template <typename Action, typename Observation, typename Status_t = Status>
 class RobotBinaryLogReader
 {
 public:
-    typedef RobotLogEntry<Action, Observation> LogEntry;
+    typedef RobotLogEntry<Action, Observation, Status_t> LogEntry;
 
     std::vector<LogEntry> data;
 

--- a/include/robot_interfaces/robot_log_reader.hpp
+++ b/include/robot_interfaces/robot_log_reader.hpp
@@ -30,9 +30,15 @@ template <typename Action, typename Observation, typename Status_t = Status>
 class RobotBinaryLogReader
 {
 public:
+    static constexpr uint32_t FORMAT_VERSION = 2;
+
     typedef RobotLogEntry<Action, Observation, Status_t> LogEntry;
 
     std::vector<LogEntry> data;
+
+    RobotBinaryLogReader()
+    {
+    }
 
     //! @copydoc RobotBinaryLogReader::read_file()
     RobotBinaryLogReader(const std::string &filename)
@@ -61,12 +67,30 @@ public:
         std::uint32_t format_version;
         archive(format_version);
 
-        if (format_version != 2)
+        if (format_version != FORMAT_VERSION)
         {
             throw std::runtime_error("Incompatible log file format.");
         }
 
         archive(data);
+    }
+
+    /**
+     * @brief Write data to the specified file.
+     *
+     * @param filename Path to the output file.
+     */
+    void write_file(const std::string &filename)
+    {
+        std::ofstream outfile(filename, std::ios::binary);
+        if (!outfile)
+        {
+            throw std::runtime_error("Failed to open file " + filename);
+        }
+        auto outfile_compressed = gzip_ostream(outfile);
+        cereal::BinaryOutputArchive archive(*outfile_compressed);
+
+        archive(FORMAT_VERSION, data);
     }
 };
 

--- a/src/convert_old_robot_log.cpp
+++ b/src/convert_old_robot_log.cpp
@@ -1,0 +1,102 @@
+/**
+ * @file
+ * @brief Convert old TriFinger robot logs from before the fix in
+ *        Status::error_message.
+ *
+ * In the past Status::error_message was a variable-sized std::string.  Since
+ * this is incompatible with the fixed-size requirement for shared memory time
+ * series, it was changed to a fixed-size char-array in commit 4ca02a17.
+ * Unfortunately, this makes old logfiles incompatible with the RobotLogReader
+ * using the fixed type.
+ *
+ * This file provides a utility to load log files of the old format and convert
+ * them to the new format, so that they can be processed with the latest version
+ * of the code.
+ *
+ * @copyright Copyright (c) 2021, Max Planck Gesellschaft.
+ * @license BSD 3-clause
+ */
+#include <filesystem>
+#include <iostream>
+#include <string>
+#include <vector>
+
+#include <cereal/types/string.hpp>
+
+#include <robot_interfaces/finger_types.hpp>
+#include <robot_interfaces/status.hpp>
+
+using namespace robot_interfaces;
+
+//! Old version of the Status message (taken from commit 4ca02a17^, stripped
+//! down to the relevant parts).
+struct OldStatus
+{
+    uint32_t action_repetitions = 0;
+    Status::ErrorStatus error_status = Status::ErrorStatus::NO_ERROR;
+    std::string error_message;
+
+    template <class Archive>
+    void serialize(Archive& archive)
+    {
+        archive(action_repetitions, error_status, error_message);
+    }
+};
+
+typedef RobotBinaryLogReader<TriFingerTypes::Action,
+                             TriFingerTypes::Observation,
+                             OldStatus>
+    OldLogReader;
+
+int main(int argc, char* argv[])
+{
+    if (argc != 3)
+    {
+        std::cerr << "Error: Invalid number of arguments." << std::endl;
+        std::cerr << "Usage: " << argv[0] << " <old_logfile> <new_logfile>"
+                  << std::endl;
+        return 1;
+    }
+
+    std::string old_logfile(argv[1]);
+    std::string new_logfile(argv[2]);
+
+    if (!std::filesystem::is_regular_file(old_logfile))
+    {
+        std::cout << "Error: Input " << old_logfile << " is not a regular file."
+                  << std::endl;
+        return 2;
+    }
+    if (std::filesystem::exists(new_logfile))
+    {
+        std::cout << "Error: Output destination " << new_logfile
+                  << " already exists." << std::endl;
+        return 3;
+    }
+
+    OldLogReader old_log(old_logfile);
+    TriFingerTypes::BinaryLogReader new_log;
+
+    // copy data
+    for (OldLogReader::LogEntry old_entry : old_log.data)
+    {
+        TriFingerTypes::BinaryLogReader::LogEntry new_entry;
+
+        // copy all fields that are unchanged
+        new_entry.timeindex = old_entry.timeindex;
+        new_entry.timestamp = old_entry.timestamp;
+        new_entry.observation = old_entry.observation;
+        new_entry.desired_action = old_entry.desired_action;
+        new_entry.applied_action = old_entry.applied_action;
+
+        // copy status
+        new_entry.status.action_repetitions =
+            old_entry.status.action_repetitions;
+        new_entry.status.set_error(old_entry.status.error_status,
+                                   old_entry.status.error_message);
+
+        new_log.data.push_back(new_entry);
+    }
+
+    new_log.write_file(new_logfile);
+}


### PR DESCRIPTION
[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add application to convert old robot log files (from before the change of `Status` in 4ca02a17) to the new format, so they can be read by the current version of the software.

For this make the `Status` type of `BinaryRobotLogReader` configurable and add a method `write_file()` to easily store the converted log.


## How I Tested

By running it on some old logs.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
