### PR TITLE
fix: Do not block in RobotLogger::stop() if buffer is empty

### DIFF
--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -692,7 +692,13 @@ private:
     //! Get observations from logger_data_ and add them to the buffer.
     void buffer_loop()
     {
-        auto t = logger_data_->observation->oldest_timeindex();
+        // Get the oldest available timeindex as starting point of the log.  In
+        // case there is no data yet (t == EMPTY), start with t = 0.
+        auto t = logger_data_->observation->oldest_timeindex(false);
+        if (t == time_series::EMPTY)
+        {
+            t = 0;
+        }
 
         while (enabled_)
         {

--- a/tests/test_robot_logger.cpp
+++ b/tests/test_robot_logger.cpp
@@ -293,6 +293,39 @@ TEST_F(TestRobotLogger, start_stop_csv_gzip)
     check_csv_log(logfile, 0, max_number_of_actions, true);
 }
 
+TEST_F(TestRobotLogger, start_stop_empty_binary)
+{
+    Logger logger(data, 10);
+    backend->initialize();
+
+    // start and directly stop again without sending any actions
+    logger.start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    logger.stop_and_save(logfile, Logger::Format::BINARY);
+
+    // log should be empty
+    BinaryLogReader log(logfile);
+    ASSERT_TRUE(log.data.empty());
+}
+
+TEST_F(TestRobotLogger, start_stop_empty_csv)
+{
+    Logger logger(data, 10);
+    backend->initialize();
+
+    // start and directly stop again without sending any actions
+    logger.start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+    logger.stop_and_save(logfile, Logger::Format::BINARY);
+
+    // log should be empty (apart from header line)
+    std::string line;
+    std::ifstream infile(logfile);
+    ASSERT_TRUE(std::getline(infile, line)) << "Failed to read header line";
+    ASSERT_FALSE(std::getline(infile, line))
+        << "Unexpected second line: " << line;
+}
+
 TEST_F(TestRobotLogger, start_stop_continuous)
 {
     // make sure the logger buffer is large enough


### PR DESCRIPTION
## Description
Do not wait for `oldest_timeindex()` when starting the logger.  Instead, simply assume that the first step is `t = 0` if there is no data yet.

This resolves an issue that `stop()` was blocking forever when the logger was stopped before any data was received.

Add unit tests to cover this case.


## How I Tested

By running the unit tests and by using it on the submission system with a user code that does not send any actions (and thus never starts the robot).


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
