### PR TITLE
Add script to binary trifinger robot log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,13 @@ install(
   INCLUDES
   DESTINATION include)
 
+install_scripts(
+    scripts/plot_trifinger_log.py
+
+    DESTINATION lib/${PROJECT_NAME}
+)
+
+
 #
 # Export the package as ament
 #

--- a/scripts/plot_trifinger_log.py
+++ b/scripts/plot_trifinger_log.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Plot selected data fields of a TriFinger robot log.
+
+Specify one or more fields that are to be plotted.  The names correspond to the
+data entries of the ``RobotLogEntry`` class.  For fields that contain vectors
+(e.g. joint positions), add a index to the name.  Example:
+
+    status.action_repetitions
+    observation.position[0]    <- plot observed positions of joint 0
+"""
+import argparse
+import re
+import sys
+import typing
+
+import matplotlib.pyplot as plt
+
+import robot_interfaces
+
+
+def get_data(
+    log: robot_interfaces.trifinger.BinaryLogReader, field_name: str
+) -> typing.List[typing.Any]:
+    """Extract data of the given field from the robot log.
+
+    Args:
+        log: Robot log.
+        field_name: Name of the data field.  Corresponds to the name of the
+            attribute in the ``RobotLogEntry``, e.g.
+            "status.action_repetitions" or "observation.position[0]" ([0]
+            specifies to take the values of joint 0).
+
+    Returns:
+        The extracted data.
+    """
+    # extract index if one is given
+    index = None
+    m = re.match(r"(.*)\[(\d+)\]$", field_name)
+    if m:
+        field_name = m.group(1)
+        index = int(m.group(2))
+
+    data = log.data
+    for field_component in field_name.split("."):
+        data = [getattr(entry, field_component) for entry in data]
+
+    if index is not None:
+        data = [entry[index] for entry in data]
+
+    return data
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("filename", type=str, help="The trifinger robot log file.")
+    parser.add_argument(
+        "fields",
+        type=str,
+        nargs="+",
+        help="One or more data fields that are added to the plot.",
+    )
+    parser.add_argument(
+        "--base",
+        type=str,
+        default="timeindex",
+        help="Data field that is used for the x-axis. Default: %(default)s",
+    )
+    args = parser.parse_args()
+
+    log = robot_interfaces.trifinger.BinaryLogReader(args.filename)
+
+    base_data = get_data(log, args.base)
+    for field in args.fields:
+        field_data = get_data(log, field)
+        plt.plot(base_data, field_data, label=field)
+
+    plt.legend()
+    plt.xlabel(args.base)
+    plt.show()
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION


[//]: # "Thanks for your contribution.  To make life of the reviewers easier,"
[//]: # "please give this pull request a meaningful title and provide the"
[//]: # "requested information below."

## Description

Add a simple script that can print selected fields of a given binary
robot log file.

This is supposed to serve as a replacement for robot_fingers/plot_logged_data.py which requires a CSV log file.


## How I Tested

By running it.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
