### PR TITLE
fix: Do not block sensor logger if there is no data

### DIFF
--- a/include/robot_interfaces/sensors/sensor_logger.hpp
+++ b/include/robot_interfaces/sensors/sensor_logger.hpp
@@ -145,7 +145,13 @@ private:
     //! Get observations from sensor_data_ and add them to the buffer.
     void loop()
     {
-        auto t = sensor_data_->observation->oldest_timeindex();
+        // Get the oldest available timeindex as starting point of the log.  In
+        // case there is no data yet (t == EMPTY), start with t = 0.
+        auto t = sensor_data_->observation->oldest_timeindex(false);
+        if (t == time_series::EMPTY)
+        {
+            t = 0;
+        }
 
         while (enabled_)
         {

--- a/include/robot_interfaces/sensors/sensor_logger.hpp
+++ b/include/robot_interfaces/sensors/sensor_logger.hpp
@@ -147,7 +147,8 @@ private:
     {
         // Get the oldest available timeindex as starting point of the log.  In
         // case there is no data yet (t == EMPTY), start with t = 0.
-        auto t = sensor_data_->observation->oldest_timeindex(false);
+        time_series::Index t =
+            sensor_data_->observation->oldest_timeindex(false);
         if (t == time_series::EMPTY)
         {
             t = 0;


### PR DESCRIPTION
## Description

Instead of blocking and waiting for the oldest time index, simply start
with `t = 0` if there is no data yet in the beginning.  The same fix has
already been applied recently on the RobotLogger class and prevents the
`stop()` method from blocking forever in case the logger is stopped
before any data is received.


## How I Tested

By running robot_fingers/trifinger_data_backend.py (without any other scripts, so no data is added to the time series) and stopping it.  Without this fix it was blocking in the "save camera log" step, with the fix it doesn't.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
