### PR TITLE
Move and pybind RobotBackend TerminationReason

### DIFF
--- a/srcpy/py_generic.cpp
+++ b/srcpy/py_generic.cpp
@@ -7,6 +7,7 @@
 #include <time_series/pybind11_helper.hpp>
 
 #include <robot_interfaces/pybind_helper.hpp>
+#include <robot_interfaces/robot_backend.hpp>
 #include <robot_interfaces/status.hpp>
 
 using namespace robot_interfaces;
@@ -41,4 +42,17 @@ PYBIND11_MODULE(py_generic, m)
     time_series::create_python_bindings<Status>(m, "_StatusTimeSeries");
     time_series::create_multiprocesses_python_bindings<Status>(
         m, "_StatusMultiProcessTimeSeries");
+
+    pybind11::enum_<RobotBackendTerminationReason>(
+        m, "RobotBackendTerminationReason")
+        .value("NOT_TERMINATED", RobotBackendTerminationReason::NOT_TERMINATED)
+        .value("SHUTDOWN_REQUESTED",
+               RobotBackendTerminationReason::SHUTDOWN_REQUESTED)
+        .value("MAXIMUM_NUMBER_OF_ACTIONS_REACHED",
+               RobotBackendTerminationReason::MAXIMUM_NUMBER_OF_ACTIONS_REACHED)
+        .value("DRIVER_ERROR", RobotBackendTerminationReason::DRIVER_ERROR)
+        .value("FIRST_ACTION_TIMEOUT",
+               RobotBackendTerminationReason::FIRST_ACTION_TIMEOUT)
+        .value("NEXT_ACTION_TIMEOUT",
+               RobotBackendTerminationReason::NEXT_ACTION_TIMEOUT);
 }


### PR DESCRIPTION
## Description

Move the (template-independent) `TerminationReason` enum out of the
`RobotBackend` class, so it can be used without having to specify
template types of the backend.  This allows to add generic Python
bindings for the enum.


## How I Tested

Use the new Python bindings in https://github.com/open-dynamic-robot-initiative/robot_fingers/pull/122


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
