### PR TITLE
Pickle-support for bound Action/Observation/Status types

### DIFF
--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -20,8 +20,8 @@ namespace robot_interfaces
 /**
  * @bind Add Python bindings for Types::Observaton::tip_force if it exists.
  *
- * Uses black SFINAE magic to add bindings for "tip_force" if it exists and do
- * nothing if it does not.
+ * Uses black SFINAE magic to add bindings for "tip_force" if it exists.
+ * Further the pickle functions differ due to this, so handle this here as well.
  *
  * Usage:
  *
@@ -33,9 +33,25 @@ namespace robot_interfaces
 template <typename Types, typename = int>
 struct BindTipForceIfExists
 {
-    static void bind(pybind11::class_<typename Types::Observation> &)
+    static void bind(pybind11::class_<typename Types::Observation> &c)
     {
-        // tip_force does not exist, so do nothing
+        c.def(pybind11::pickle(
+            [](const typename Types::Observation &o) {  // __getstate__
+                return pybind11::make_tuple(o.position, o.velocity, o.torque);
+            },
+            [](pybind11::tuple t) {  // __setstate__
+                if (t.size() != 3)
+                {
+                    throw std::runtime_error("Invalid state!");
+                }
+
+                typename Types::Observation obs;
+                obs.position = t[0].cast<typename Types::Observation::Vector>();
+                obs.velocity = t[1].cast<typename Types::Observation::Vector>();
+                obs.torque = t[2].cast<typename Types::Observation::Vector>();
+
+                return obs;
+            }));
     }
 };
 template <typename Types>
@@ -48,6 +64,30 @@ struct BindTipForceIfExists<Types,
                         &Types::Observation::tip_force,
                         "Measurements of the push sensors at the finger tips, "
                         "one per finger. Ranges between 0 and 1.");
+
+        c.def(pybind11::pickle(
+            [](const typename Types::Observation &o) {  // __getstate__
+                return pybind11::make_tuple(
+                    o.position, o.velocity, o.torque, o.tip_force);
+            },
+            [](pybind11::tuple t) {  // __setstate__
+                if (t.size() != 4)
+                {
+                    throw std::runtime_error("Invalid state!");
+                }
+
+                typename Types::Observation obs;
+                obs.position =
+                    t[0].cast<typename Types::Observation::JointVector>();
+                obs.velocity =
+                    t[1].cast<typename Types::Observation::JointVector>();
+                obs.torque =
+                    t[2].cast<typename Types::Observation::JointVector>();
+                obs.tip_force =
+                    t[3].cast<typename Types::Observation::FingerVector>();
+
+                return obs;
+            }));
     }
 };
 
@@ -186,7 +226,28 @@ void create_python_bindings(pybind11::module &m)
              pybind11::arg("torque") = Types::Action::Vector::Zero(),
              pybind11::arg("position") = Types::Action::None(),
              pybind11::arg("position_kp") = Types::Action::None(),
-             pybind11::arg("position_kd") = Types::Action::None());
+             pybind11::arg("position_kd") = Types::Action::None())
+        .def(pybind11::pickle(
+            [](const typename Types::Action &a) {  // __getstate__
+                // Return a tuple that fully encodes the state of the object
+                return pybind11::make_tuple(
+                    a.torque, a.position, a.position_kp, a.position_kd);
+            },
+            [](pybind11::tuple t) {  // __setstate__
+                if (t.size() != 4)
+                {
+                    throw std::runtime_error("Invalid state!");
+                }
+
+                // Create a new C++ instance
+                typename Types::Action action(
+                    t[0].cast<typename Types::Action::Vector>(),
+                    t[1].cast<typename Types::Action::Vector>(),
+                    t[2].cast<typename Types::Action::Vector>(),
+                    t[3].cast<typename Types::Action::Vector>());
+
+                return action;
+            }));
 
     auto obs =
         pybind11::class_<typename Types::Observation>(m, "Observation")
@@ -281,38 +342,40 @@ void create_python_bindings(pybind11::module &m)
              pybind11::arg("end_index") = -1,
              pybind11::call_guard<pybind11::gil_scoped_release>())
         // raise warining when using deprecated method
-        .def("write_current_buffer",
-             [](pybind11::object &self,
-                const std::string &filename,
-                long int start_index,
-                long int end_index) {
-                 auto warnings = pybind11::module::import("warnings");
-                 warnings.attr("warn")(
-                     "write_current_buffer() is deprecated, use "
-                     "save_current_robot_data() "
-                     "instead.");
-                 return self.attr("save_current_robot_data")(
-                     filename, start_index, end_index);
-             },
-             pybind11::arg("filename"),
-             pybind11::arg("start_index") = 0,
-             pybind11::arg("end_index") = -1)
-        .def("write_current_buffer_binary",
-             [](pybind11::object &self,
-                const std::string &filename,
-                long int start_index,
-                long int end_index) {
-                 auto warnings = pybind11::module::import("warnings");
-                 warnings.attr("warn")(
-                     "write_current_buffer_binary() is deprecated, use "
-                     "save_current_robot_data_binary() "
-                     "instead.");
-                 return self.attr("save_current_robot_data_binary")(
-                     filename, start_index, end_index);
-             },
-             pybind11::arg("filename"),
-             pybind11::arg("start_index") = 0,
-             pybind11::arg("end_index") = -1);
+        .def(
+            "write_current_buffer",
+            [](pybind11::object &self,
+               const std::string &filename,
+               long int start_index,
+               long int end_index) {
+                auto warnings = pybind11::module::import("warnings");
+                warnings.attr("warn")(
+                    "write_current_buffer() is deprecated, use "
+                    "save_current_robot_data() "
+                    "instead.");
+                return self.attr("save_current_robot_data")(
+                    filename, start_index, end_index);
+            },
+            pybind11::arg("filename"),
+            pybind11::arg("start_index") = 0,
+            pybind11::arg("end_index") = -1)
+        .def(
+            "write_current_buffer_binary",
+            [](pybind11::object &self,
+               const std::string &filename,
+               long int start_index,
+               long int end_index) {
+                auto warnings = pybind11::module::import("warnings");
+                warnings.attr("warn")(
+                    "write_current_buffer_binary() is deprecated, use "
+                    "save_current_robot_data_binary() "
+                    "instead.");
+                return self.attr("save_current_robot_data_binary")(
+                    filename, start_index, end_index);
+            },
+            pybind11::arg("filename"),
+            pybind11::arg("start_index") = 0,
+            pybind11::arg("end_index") = -1);
 
     pybind11::enum_<typename Types::Logger::Format>(logger, "Format")
         .value("BINARY", Types::Logger::Format::BINARY)

--- a/package.xml
+++ b/package.xml
@@ -8,7 +8,7 @@
 
     <name>robot_interfaces</name>
     <version>1.0.0</version>
-    
+
     <description>
         This package provides C++ interfaces (purely virtual classes) for
         different robots. The idea is to use this interface both for the real
@@ -36,9 +36,10 @@
     <depend>serialization_utils</depend>
     <depend>Threads</depend>
     <depend>rt</depend>
-    
+
     <!-- Unit tests -->
     <test_depend>ament_cmake_gtest</test_depend>
+    <test_depend>ament_cmake_pytest</test_depend>
     <test_depend>Boost</test_depend>
 
     <export>

--- a/srcpy/py_generic.cpp
+++ b/srcpy/py_generic.cpp
@@ -24,7 +24,26 @@ PYBIND11_MODULE(py_generic, m)
                       &Status::error_status,
                       "ErrorStatus: Current error status.")
         .def("set_error", &Status::set_error)
-        .def("get_error_message", &Status::get_error_message);
+        .def("get_error_message", &Status::get_error_message)
+        .def(pybind11::pickle(
+            [](const Status &status) {  // __getstate__
+                return pybind11::make_tuple(status.action_repetitions,
+                                            status.error_status,
+                                            status.get_error_message());
+            },
+            [](pybind11::tuple t) {  // __setstate__
+                if (t.size() != 3)
+                {
+                    throw std::runtime_error("Invalid state!");
+                }
+
+                Status status;
+                status.action_repetitions = t[0].cast<int>();
+                status.set_error(t[1].cast<Status::ErrorStatus>(),
+                                 t[2].cast<std::string>());
+
+                return status;
+            }));
 
     pybind11::enum_<Status::ErrorStatus>(pystatus, "ErrorStatus")
         .value("NO_ERROR",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,6 +3,7 @@
 #
 
 find_package(ament_cmake_gtest REQUIRED)
+find_package(ament_cmake_pytest REQUIRED)
 find_package(Boost REQUIRED COMPONENTS filesystem)
 
 macro(create_unittest test_name)
@@ -17,3 +18,6 @@ create_unittest(test_robot_backend)
 create_unittest(test_robot_logger)
 create_unittest(test_sensor_interface)
 create_unittest(test_sensor_logger)
+
+# Python tests
+ament_add_pytest_test(test_pybind_pickle_py test_pybind_pickle.py)

--- a/tests/test_pybind_pickle.py
+++ b/tests/test_pybind_pickle.py
@@ -1,0 +1,99 @@
+"""Unit tests verifying that pickling of bound types works as expected."""
+import pickle
+import numpy as np
+
+import robot_interfaces
+
+
+def test_pickle_finger_action():
+    action = robot_interfaces.finger.Action(
+        torque=[1, 2, 3],
+        position=[4, 5, 6],
+        position_kp=[0.1, 0.2, 0.3],
+        position_kd=[11, 22, 33],
+    )
+
+    pickled = pickle.dumps(action)
+    unpickled = pickle.loads(pickled)
+
+    np.testing.assert_array_equal(action.torque, unpickled.torque)
+    np.testing.assert_array_equal(action.position, unpickled.position)
+    np.testing.assert_array_equal(action.position_kp, unpickled.position_kp)
+    np.testing.assert_array_equal(action.position_kd, unpickled.position_kd)
+
+
+def test_pickle_trifinger_action():
+    action = robot_interfaces.trifinger.Action(
+        torque=[1, 2, 3, 4, 5, 6, 7, 8, 9],
+        position=[11, 22, 33, 44, 55, 66, 77, 88, 99],
+        position_kp=[0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9],
+        position_kd=[1.1, 2.2, 3.3, 4.4, 5.5, 6.6, 7.7, 8.8, 9.9],
+    )
+
+    pickled = pickle.dumps(action)
+    unpickled = pickle.loads(pickled)
+
+    np.testing.assert_array_equal(action.torque, unpickled.torque)
+    np.testing.assert_array_equal(action.position, unpickled.position)
+    np.testing.assert_array_equal(action.position_kp, unpickled.position_kp)
+    np.testing.assert_array_equal(action.position_kd, unpickled.position_kd)
+
+
+def test_pickle_finger_observation():
+    obs = robot_interfaces.finger.Observation()
+    obs.torque = [1, 2, 3]
+    obs.velocity = [11, 22, 33]
+    obs.position = [111, 222, 333]
+    obs.tip_force = [1111]
+
+    pickled = pickle.dumps(obs)
+    unpickled = pickle.loads(pickled)
+
+    np.testing.assert_array_equal(obs.torque, unpickled.torque)
+    np.testing.assert_array_equal(obs.velocity, unpickled.velocity)
+    np.testing.assert_array_equal(obs.position, unpickled.position)
+    np.testing.assert_array_equal(obs.tip_force, unpickled.tip_force)
+
+
+def test_pickle_trifinger_observation():
+    obs = robot_interfaces.trifinger.Observation()
+    obs.torque = [1, 2, 3, 4, 5, 6, 7, 8, 9]
+    obs.velocity = [11, 22, 33, 44, 55, 66, 77, 88, 99]
+    obs.position = [111, 222, 333, 444, 555, 666, 777, 888, 999]
+    obs.tip_force = [1111, 2222, 3333]
+
+    pickled = pickle.dumps(obs)
+    unpickled = pickle.loads(pickled)
+
+    np.testing.assert_array_equal(obs.torque, unpickled.torque)
+    np.testing.assert_array_equal(obs.velocity, unpickled.velocity)
+    np.testing.assert_array_equal(obs.position, unpickled.position)
+    np.testing.assert_array_equal(obs.tip_force, unpickled.tip_force)
+
+
+def test_pickle_one_joint_observation():
+    # one_joint observations do not have a "tip_force"
+    obs = robot_interfaces.one_joint.Observation()
+    obs.torque = [1]
+    obs.velocity = [11]
+    obs.position = [111]
+
+    pickled = pickle.dumps(obs)
+    unpickled = pickle.loads(pickled)
+
+    np.testing.assert_array_equal(obs.torque, unpickled.torque)
+    np.testing.assert_array_equal(obs.velocity, unpickled.velocity)
+    np.testing.assert_array_equal(obs.position, unpickled.position)
+
+
+def test_pickle_status():
+    status = robot_interfaces.Status()
+    status.action_repetitions = 42
+    status.set_error(status.ErrorStatus.DRIVER_ERROR, "some message")
+
+    pickled = pickle.dumps(status)
+    unpickled = pickle.loads(pickled)
+
+    assert unpickled.action_repetitions == 42
+    assert unpickled.error_status == status.ErrorStatus.DRIVER_ERROR
+    assert unpickled.get_error_message() == "some message"


### PR DESCRIPTION
## Description

Add pickle-support for bound robot Action, Observation and Status types.
This implicitly also adds support for deepcopy.


## How I Tested

Using the unit test added in this PR.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
