### PR TITLE
Suppress internal deprecation warnings & add warnings for Python bindings

### DIFF
--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -378,12 +378,32 @@ void create_python_bindings(pybind11::module &m)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     logger
-        .def("start_continous_writing",
+        .def("_start_continous_writing",
              &Types::Logger::start_continous_writing,
              pybind11::call_guard<pybind11::gil_scoped_release>())
-        .def("stop_continous_writing",
+        .def(
+            "start_continous_writing",
+            [](pybind11::object &self, const std::string &filename)
+            {
+                auto warnings = pybind11::module::import("warnings");
+                warnings.attr("warn")(
+                    "start_continous_writing() is deprecated and will be"
+                    " removed in a future version.");
+                return self.attr("_start_continous_writing")(filename);
+            },
+            pybind11::arg("filename"))
+        .def("_stop_continous_writing",
              &Types::Logger::stop_continous_writing,
-             pybind11::call_guard<pybind11::gil_scoped_release>());
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("stop_continous_writing",
+             [](pybind11::object &self)
+             {
+                 auto warnings = pybind11::module::import("warnings");
+                 warnings.attr("warn")(
+                     "stop_continous_writing() is deprecated and will be"
+                     " removed in a future version.");
+                 return self.attr("_stop_continous_writing")();
+             });
 #pragma GCC diagnostic pop
 
     pybind11::enum_<typename Types::Logger::Format>(logger, "Format")

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -323,12 +323,6 @@ void create_python_bindings(pybind11::module &m)
         .def("reset",
              &Types::Logger::reset,
              pybind11::call_guard<pybind11::gil_scoped_release>())
-        .def("start_continous_writing",
-             &Types::Logger::start_continous_writing,
-             pybind11::call_guard<pybind11::gil_scoped_release>())
-        .def("stop_continous_writing",
-             &Types::Logger::stop_continous_writing,
-             pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("save_current_robot_data",
              &Types::Logger::save_current_robot_data,
              pybind11::arg("filename"),
@@ -378,6 +372,19 @@ void create_python_bindings(pybind11::module &m)
             pybind11::arg("filename"),
             pybind11::arg("start_index") = 0,
             pybind11::arg("end_index") = -1);
+
+// start/stop_continous_writing are deprecated but we still want to have the
+// bindings as long as they are there, so suppress the warning locally.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    logger
+        .def("start_continous_writing",
+             &Types::Logger::start_continous_writing,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("stop_continous_writing",
+             &Types::Logger::stop_continous_writing,
+             pybind11::call_guard<pybind11::gil_scoped_release>());
+#pragma GCC diagnostic pop
 
     pybind11::enum_<typename Types::Logger::Format>(logger, "Format")
         .value("BINARY", Types::Logger::Format::BINARY)

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -741,7 +741,7 @@ private:
             // Stop logging if buffer limit is reached
             if (buffer_.size() >= buffer_limit_)
             {
-                std::cerr << "WARNING: SensorLogger buffer limit is reached.  "
+                std::cerr << "WARNING: RobotLogger buffer limit is reached.  "
                              "Stop logging."
                           << std::endl;
                 enabled_ = false;

--- a/tests/test_robot_logger.cpp
+++ b/tests/test_robot_logger.cpp
@@ -326,6 +326,10 @@ TEST_F(TestRobotLogger, start_stop_empty_csv)
         << "Unexpected second line: " << line;
 }
 
+// start/stop_continous_writing are deprecated but we still want to have the
+// unit test as long as they are there, so suppress the warning locally
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 TEST_F(TestRobotLogger, start_stop_continuous)
 {
     // make sure the logger buffer is large enough
@@ -358,3 +362,4 @@ TEST_F(TestRobotLogger, start_stop_continuous)
 
     check_csv_log(logfile, 0, max_number_of_actions, false);
 }
+#pragma GCC diagnostic pop


### PR DESCRIPTION
## Description
- Suppress deprecation warnings of own methods in Python bindings and unit tests.
- Add deprecation warnings to the corresponding Python bindings (i.e. when called from Python).
- Fix name of class in output.


## How I Tested

By compiling and running the logger demo from robot_fingers (with local modifications).


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
