### PR TITLE
Add Ptr/ConstPtr typedefs to relevant classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 ## [Unreleased]
+### Added
+- Add `Ptr` and `ConstPtr` typedefs in classes for more conveniently defining
+  shared pointers.
 
 ## [1.2.0] - 2022-06-28
 ### Added

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -65,6 +65,9 @@ template <typename Action, typename Observation>
 class RobotBackend
 {
 public:
+    typedef std::shared_ptr<RobotBackend<Action, Observation>> Ptr;
+    typedef std::shared_ptr<const RobotBackend<Action, Observation>> ConstPtr;
+
     /**
      * @param robot_driver  Driver instance for the actual robot.
      * @param robot_data  Data is send to/retrieved from here.

--- a/include/robot_interfaces/robot_data.hpp
+++ b/include/robot_interfaces/robot_data.hpp
@@ -50,6 +50,9 @@ template <typename Action, typename Observation>
 class RobotData
 {
 public:
+    typedef std::shared_ptr<RobotData<Action, Observation>> Ptr;
+    typedef std::shared_ptr<const RobotData<Action, Observation>> ConstPtr;
+
     //! @brief Time series of the desired actions.
     std::shared_ptr<time_series::TimeSeriesInterface<Action>> desired_action;
     //! @brief Time series of the actually applied actions (due to safety

--- a/include/robot_interfaces/robot_frontend.hpp
+++ b/include/robot_interfaces/robot_frontend.hpp
@@ -36,6 +36,8 @@ template <typename Action, typename Observation>
 class RobotFrontend
 {
 public:
+    typedef std::shared_ptr<RobotFrontend<Action, Observation>> Ptr;
+    typedef std::shared_ptr<const RobotFrontend<Action, Observation>> ConstPtr;
     typedef time_series::Timestamp TimeStamp;
 
     RobotFrontend(std::shared_ptr<RobotData<Action, Observation>> robot_data)

--- a/include/robot_interfaces/sensors/sensor_backend.hpp
+++ b/include/robot_interfaces/sensors/sensor_backend.hpp
@@ -31,6 +31,9 @@ template <typename ObservationType>
 class SensorBackend
 {
 public:
+    typedef std::shared_ptr<SensorBackend<ObservationType>> Ptr;
+    typedef std::shared_ptr<const SensorBackend<ObservationType>> ConstPtr;
+
     /**
      * @param sensor_driver  Driver instance for the sensor.
      * @param sensor_data  Data is sent to/retrieved from here.

--- a/include/robot_interfaces/sensors/sensor_data.hpp
+++ b/include/robot_interfaces/sensors/sensor_data.hpp
@@ -27,6 +27,9 @@ template <typename Observation>
 class SensorData
 {
 public:
+    typedef std::shared_ptr<SensorData<Observation>> Ptr;
+    typedef std::shared_ptr<const SensorData<Observation>> ConstPtr;
+
     //! @brief Time series of the sensor observations.
     std::shared_ptr<time_series::TimeSeriesInterface<Observation>> observation;
 

--- a/include/robot_interfaces/sensors/sensor_frontend.hpp
+++ b/include/robot_interfaces/sensors/sensor_frontend.hpp
@@ -32,6 +32,9 @@ class SensorFrontend
 public:
     template <typename Type>
     using Timeseries = time_series::TimeSeries<Type>;
+
+    typedef std::shared_ptr<SensorFrontend<ObservationType>> Ptr;
+    typedef std::shared_ptr<const SensorFrontend<ObservationType>> ConstPtr;
     typedef time_series::Timestamp TimeStamp;
     typedef time_series::Index TimeIndex;
 


### PR DESCRIPTION
## Description
Add Ptr/ConstPtr typedefs to relevant classes


## How I Tested
By using them in a new (not yet public) package.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
