### PR TITLE
fix (monitored driver): Forward call to get_idle_action()

### DIFF
--- a/include/robot_interfaces/monitored_robot_driver.hpp
+++ b/include/robot_interfaces/monitored_robot_driver.hpp
@@ -110,8 +110,8 @@ public:
      * @return  The action that is actually applied on the robot (may differ
      *     from desired action due to safety limitations).
      */
-    virtual typename Driver::Action apply_action(
-        const typename Driver::Action &desired_action) final
+    typename Driver::Action apply_action(
+        const typename Driver::Action &desired_action) final override
     {
         if (is_shutdown_)
         {
@@ -126,17 +126,17 @@ public:
         return applied_action;
     }
 
-    virtual void initialize()
+    void initialize() override
     {
         robot_driver_->initialize();
     }
 
-    virtual typename Driver::Observation get_latest_observation()
+    typename Driver::Observation get_latest_observation() override
     {
         return robot_driver_->get_latest_observation();
     }
 
-    virtual std::string get_error()
+    std::string get_error() override
     {
         const std::string driver_error = robot_driver_->get_error();
         if (driver_error.empty())
@@ -154,7 +154,7 @@ public:
      *
      * After shutdown, actions sent by the user are ignored.
      */
-    virtual void shutdown() final
+    void shutdown() final override
     {
         if (!is_shutdown_)
         {

--- a/include/robot_interfaces/monitored_robot_driver.hpp
+++ b/include/robot_interfaces/monitored_robot_driver.hpp
@@ -131,6 +131,11 @@ public:
         robot_driver_->initialize();
     }
 
+    typename Driver::Action get_idle_action() override
+    {
+        return robot_driver_->get_idle_action();
+    }
+
     typename Driver::Observation get_latest_observation() override
     {
         return robot_driver_->get_latest_observation();


### PR DESCRIPTION
## Description

Without this, the monitored driver was always using the implementation of the base `RobotDriver` class, ignoring any custom implementations.


## How I Tested
In conjunction with https://github.com/open-dynamic-robot-initiative/robot_fingers/pull/150.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
