### PR TITLE
Fix clang-tidy warnings

### DIFF
--- a/include/robot_interfaces/loggable.hpp
+++ b/include/robot_interfaces/loggable.hpp
@@ -18,6 +18,11 @@ namespace robot_interfaces
 class Loggable
 {
 public:
+    // virtual destructor is needed for class with virtual methods
+    virtual ~Loggable()
+    {
+    }
+
     /*
      * @brief Return the names of the fields in the structure.
      * Current restriction: a returned name should not have spaces between

--- a/include/robot_interfaces/robot_driver.hpp
+++ b/include/robot_interfaces/robot_driver.hpp
@@ -34,6 +34,11 @@ public:
     typedef TAction Action;
     typedef TObservation Observation;
 
+    // virtual destructor is needed for class with virtual methods
+    virtual ~RobotDriver()
+    {
+    }
+
     /**
      * @brief Initialize the robot.
      *

--- a/include/robot_interfaces/sensors/sensor_driver.hpp
+++ b/include/robot_interfaces/sensors/sensor_driver.hpp
@@ -22,6 +22,11 @@ template <typename ObservationType>
 class SensorDriver
 {
 public:
+    // virtual destructor is needed for class with virtual methods
+    virtual ~SensorDriver()
+    {
+    }
+
     /**
      * @brief return the observation
      * @return depends on the observation structure

--- a/tests/test_robot_logger.cpp
+++ b/tests/test_robot_logger.cpp
@@ -127,8 +127,8 @@ protected:
                         applied_1 >> desired_0 >> desired_1);
 
             // check some of the values
-            ASSERT_EQ(time_index, i);
-            ASSERT_EQ(desired_0, i);
+            ASSERT_EQ(time_index, static_cast<int>(i));
+            ASSERT_EQ(desired_0, static_cast<int>(i));
             ASSERT_EQ(desired_1, 42);
         }
     }
@@ -187,7 +187,7 @@ TEST_F(TestRobotLogger, save_current_robot_data_binary)
     ASSERT_EQ(log.data.size(), max_number_of_actions);
     for (uint32_t i = 0; i < log.data.size(); i++)
     {
-        ASSERT_EQ(log.data[i].desired_action.values[0], i);
+        ASSERT_EQ(log.data[i].desired_action.values[0], static_cast<int>(i));
         ASSERT_EQ(log.data[i].desired_action.values[1], 42);
     }
 }
@@ -226,7 +226,7 @@ TEST_F(TestRobotLogger, start_stop_binary)
     ASSERT_EQ(log.data.size(), max_number_of_actions);
     for (uint32_t i = 0; i < log.data.size(); i++)
     {
-        ASSERT_EQ(log.data[i].desired_action.values[0], i);
+        ASSERT_EQ(log.data[i].desired_action.values[0], static_cast<int>(i));
         ASSERT_EQ(log.data[i].desired_action.values[1], 42);
     }
 }


### PR DESCRIPTION
## Description

- Add virtual destructor to base classes that did not yet have one.
- Add casts to avoid comparison of signed and unsigned in tests.


## How I Tested

`colcon build` and `colcon test`.


## I fulfilled the following requirements

[//]: # "Please make sure you followed these steps before requesting a review."
[//]: # "Check the boxes in the list below, when done."

- [x] All new code is formatted according to our style guide (for C++ run clang-format, for Python, run flake8 and fix all warnings).
- [x] All new functions/classes are documented and existing documentation is updated according to changes.
- [x] No commented code from testing/debugging is kept (unless there is a good reason to keep it).
