### PR TITLE
Indicate shortened error messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
   This change is to prevent hardware timeout issues but can also be useful to
   have nicer behaviour of the robot after initialisation (e.g. by holding the
   joints in place).
+- If an error message given to `Status::set_error()` is cut due to being too
+  long, this is now indicated by setting '~' as last character.
 
 ### Fixed
 - pybind11 build error on Ubuntu 22.04

--- a/include/robot_interfaces/status.hpp
+++ b/include/robot_interfaces/status.hpp
@@ -28,6 +28,7 @@ namespace robot_interfaces
  */
 struct Status : public Loggable
 {
+    //! Maximum length of error messages (including terminating \0)
     static constexpr unsigned int ERROR_MESSAGE_LENGTH = 64;
 
     //! @brief Different types of errors that can occur in the backend.
@@ -87,7 +88,8 @@ struct Status : public Loggable
      * ignored.
      *
      * @param error_type  The type of the error.
-     * @param message  Error message.
+     * @param message  Error message.  Will be shortened if it exceeds @ref
+     *      ERROR_MESSAGE_LENGTH.
      */
     void set_error(ErrorStatus error_type, const std::string& message)
     {
@@ -98,6 +100,12 @@ struct Status : public Loggable
 
             std::strncpy(
                 this->error_message, message.c_str(), ERROR_MESSAGE_LENGTH - 1);
+            // in case message is too long and needs to be cut, indicate this by
+            // setting ~ as last character
+            if (message.size() > ERROR_MESSAGE_LENGTH - 1)
+            {
+                this->error_message[ERROR_MESSAGE_LENGTH - 2] = '~';
+            }
             // make sure it is terminated
             this->error_message[ERROR_MESSAGE_LENGTH - 1] = '\0';
         }


### PR DESCRIPTION
## Description
If an error message passed to Status::set_error exceeds the maximum length Status::error_message can hold (currently 64 chars including terminating \0), it simply gets cut.  This can be a bit confusing.  To hopefully make it a bit more understandable, replace the last character in the string with `~` in this case (unfortunately more appropriate characters like … are not available with standard ASCII).


## How I Tested

Using a test setup with the test bench.
