### PR TITLE
Change return type of RobotDriver::get_error to std::optional<std::string>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@
   that is safe to apply while the robot is idle.
 
 ### Changed
+- The return type of `RobotDriver::get_error()` is changed to
+  `std::optional<std::string>`.  This way instantiation of an actual string
+  (which can involve dynamic memory allocation) is only needed if there actually
+  is an error.
 - The `create_python_bindings()` function (which includes the N-joint
   action/observation) is moved to `pybind_finger.hpp` and renamed to
   `create_blmc_can_robot_python_bindings()`.

--- a/demos/demo_multiprocess_backend.cpp
+++ b/demos/demo_multiprocess_backend.cpp
@@ -79,9 +79,9 @@ public:
         return observation;
     }
 
-    std::string get_error()
+    std::optional<std::string> get_error()
     {
-        return "";  // no error
+        return std::nullopt;  // no error
     }
 
     void shutdown()

--- a/include/robot_interfaces/example.hpp
+++ b/include/robot_interfaces/example.hpp
@@ -149,9 +149,9 @@ public:
         return observation;
     }
 
-    std::string get_error()
+    std::optional<std::string> get_error()
     {
-        return "";  // no error
+        return std::nullopt;  // no error
     }
 
     void shutdown()

--- a/include/robot_interfaces/monitored_robot_driver.hpp
+++ b/include/robot_interfaces/monitored_robot_driver.hpp
@@ -11,6 +11,7 @@
 #include <atomic>
 #include <cmath>
 #include <iostream>
+#include <optional>
 
 #include <real_time_tools/process_manager.hpp>
 #include <real_time_tools/thread.hpp>
@@ -141,7 +142,7 @@ public:
         return robot_driver_->get_latest_observation();
     }
 
-    std::string get_error() override
+    std::optional<std::string> get_error() override
     {
         auto driver_error = robot_driver_->get_error();
         if (driver_error)
@@ -160,7 +161,7 @@ public:
                 break;
         }
 
-        return "";
+        return std::nullopt;
     }
 
     /**

--- a/include/robot_interfaces/monitored_robot_driver.hpp
+++ b/include/robot_interfaces/monitored_robot_driver.hpp
@@ -143,15 +143,24 @@ public:
 
     std::string get_error() override
     {
-        const std::string driver_error = robot_driver_->get_error();
-        if (driver_error.empty())
-        {
-            return error_message_.get();
-        }
-        else
+        auto driver_error = robot_driver_->get_error();
+        if (driver_error)
         {
             return driver_error;
         }
+
+        switch (error_)
+        {
+            case ErrorType::ACTION_START_TIMEOUT:
+                return "Action did not start on time, shutting down.";
+            case ErrorType::ACTION_END_TIMEOUT:
+                return "Action did not end on time, shutting down.";
+            case ErrorType::NONE:
+            default:
+                break;
+        }
+
+        return "";
     }
 
     /**
@@ -169,6 +178,13 @@ public:
     }
 
 private:
+    enum class ErrorType
+    {
+        NONE,
+        ACTION_START_TIMEOUT,
+        ACTION_END_TIMEOUT
+    };
+
     //! \brief The actual robot driver.
     RobotDriverPtr robot_driver_;
     //! \brief Max. time for executing an action.
@@ -184,7 +200,7 @@ private:
 
     std::shared_ptr<real_time_tools::RealTimeThread> thread_;
 
-    real_time_tools::SingletypeThreadsafeObject<std::string, 1> error_message_;
+    std::atomic<ErrorType> error_ = ErrorType::NONE;
 
     /**
      * @brief Monitor the timing of action execution.
@@ -208,18 +224,17 @@ private:
                                                       max_action_duration_s_);
             if (!action_has_ended_on_time)
             {
-                error_message_.set(
-                    "Action did not end on time, shutting down.");
+                error_ = ErrorType::ACTION_END_TIMEOUT;
                 shutdown();
                 return;
             }
+
             bool action_has_started_on_time =
                 action_start_logger_.wait_for_timeindex(
                     t + 1, max_inter_action_duration_s_);
             if (!action_has_started_on_time)
             {
-                error_message_.set(
-                    "Action did not start on time, shutting down.");
+                error_ = ErrorType::ACTION_START_TIMEOUT;
                 shutdown();
                 return;
             }

--- a/include/robot_interfaces/robot_backend.hpp
+++ b/include/robot_interfaces/robot_backend.hpp
@@ -13,6 +13,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
+#include <optional>
 
 #include <pybind11/embed.h>
 
@@ -397,11 +398,12 @@ private:
                 }
             }
 
-            std::string driver_error_msg = robot_driver_->get_error();
-            if (!driver_error_msg.empty())
+            std::optional<std::string> driver_error_msg =
+                robot_driver_->get_error();
+            if (driver_error_msg)
             {
                 status.set_error(Status::ErrorStatus::DRIVER_ERROR,
-                                 driver_error_msg);
+                                 *driver_error_msg);
                 termination_reason_ =
                     RobotBackendTerminationReason::DRIVER_ERROR;
             }

--- a/include/robot_interfaces/robot_driver.hpp
+++ b/include/robot_interfaces/robot_driver.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <optional>
 #include <string>
 
 namespace robot_interfaces
@@ -71,9 +72,14 @@ public:
     /**
      * @brief Get error message if there is any error.
      *
-     * @return Returns an error message or an empty string if there is no error.
+     * Uses std::optional for the return type, so an actual string only needs to
+     * be created if there is an error.  This is relevant as std::string is in
+     * general not real-time safe and should thus be avoided.  In case of an
+     * error this does not matter, as the control loop will be stopped anyway.
+     *
+     * @return Returns an error message or std::nullopt if there is no error.
      */
-    virtual std::string get_error() = 0;
+    virtual std::optional<std::string> get_error() = 0;
 
     /**
      * @brief Shut down the robot safely.


### PR DESCRIPTION
## Description

Creating a `std::string` can involve dynamic memory allocation, which should not be done within the real-time critical loop of `RobotBackend` (where `get_error()` is called in each iteration to check for errors).  As a relatively simple fix change the return type from `std::string` to `std::optional<std::string>` so in the non-error case `nullopt` can be returned instead of an empty string.  Apart from avoiding potential memory allocation, this also makes the code a bit cleaner.

In case of an error, it is still necessary to construct an `std::string` but in this case the backend loop will stop anyway, so timing violations are not really a concern anymore.

Note:  **This is a breaking change!** RobotDriver implementations need to be updated.  The necessary modification should be rather trivial, though.

## How I Tested

On a TriFinger robot.
I also compared timing but it seems the change doesn't actually change something here.  Probably creating an empty string is not actually a problem.  Still, it's better to explicitly avoid it to be sure.
