### PR TITLE
Add optional sensor_info to sensor interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   classes).
 - Method `RobotDriver::get_idle_action()` that is expected to return an action
   that is safe to apply while the robot is idle.
+- Option to provide static information about a sensor (e.g. camera calibration
+  coefficients, frame rate, etc.).  For this, a method `get_sensor_info()` is added to
+  `SensorFrontend`.  It defaults to an empty struct for backward compatibility.  To use
+  it, implement the method with the same name in `SensorDriver`.
 
 ### Changed
 - The return type of `RobotDriver::get_error()` is changed to

--- a/doc/custom_sensor.rst
+++ b/doc/custom_sensor.rst
@@ -1,0 +1,23 @@
+****************
+Sensor Interface
+****************
+
+``robot_interfaces`` also provides base classes for a pure sensor interface.  In
+contrast to a robot, a sensor only provides observations but does not take actions.
+Apart from that, the overall structure is mostly the same as for a robot.  That is,
+there are :cpp:class:`~robot_interfaces::SensorBackend` and
+:cpp:class:`~robot_interfaces::SensorFrontend` which communicate via
+:cpp:class:`~robot_interfaces::SensorData` (either single- or multi-process).
+
+For implementing an interface for your sensor, you only need to implement an observation
+type and a driver class based on :cpp:class:`~robot_interfaces::SensorDriver`.  Then
+simply create data/backend/frontend using those custom types as template arguments.
+
+Optionally, your driver class can also provide a "sensor info" object by implementing
+:cpp:func:`~robot_interfaces::SensorDriver::get_sensor_info`.  This object is then
+accessible by the user via
+:cpp:func:`~robot_interfaces::SensorFrontend::get_sensor_info`.  You may use this, to
+provide static information about the sensor, that does not change over time (e.g. frame
+rate of a camera).
+If you don't implement the corresponding method in the driver, the front end will return
+an empty struct as placeholder.

--- a/doc_mainpage.rst
+++ b/doc_mainpage.rst
@@ -15,6 +15,7 @@ paper_ on the open-source version of the TriFinger robot.
    doc/real_time.rst
    doc/quick_start_example.rst
    doc/custom_driver.rst
+   doc/custom_sensor.rst
 
 .. toctree::
    :caption: Topic Guides

--- a/include/robot_interfaces/sensors/sensor_driver.hpp
+++ b/include/robot_interfaces/sensors/sensor_driver.hpp
@@ -10,6 +10,8 @@
 
 #include <iostream>
 
+#include <robot_interfaces/utils.hpp>
+
 namespace robot_interfaces
 {
 /**
@@ -18,13 +20,24 @@ namespace robot_interfaces
  *
  * @tparam ObservationType
  */
-template <typename ObservationType>
+template <typename ObservationType, typename InfoType = None>
 class SensorDriver
 {
 public:
     // virtual destructor is needed for class with virtual methods
     virtual ~SensorDriver()
     {
+    }
+
+    /**
+     * @brief Return static information about the sensor.
+     *
+     * This information is expected to be constructed during initialization and
+     * to not change later on.
+     */
+    virtual InfoType get_sensor_info()
+    {
+        return InfoType();
     }
 
     /**

--- a/include/robot_interfaces/sensors/sensor_frontend.hpp
+++ b/include/robot_interfaces/sensors/sensor_frontend.hpp
@@ -15,6 +15,7 @@
 #include <time_series/time_series.hpp>
 
 #include <robot_interfaces/sensors/sensor_data.hpp>
+#include <robot_interfaces/utils.hpp>
 
 namespace robot_interfaces
 {
@@ -26,21 +27,28 @@ namespace robot_interfaces
  *
  * @tparam ObservationType
  */
-template <typename ObservationType>
+template <typename ObservationType, typename InfoType = None>
 class SensorFrontend
 {
 public:
     template <typename Type>
     using Timeseries = time_series::TimeSeries<Type>;
 
-    typedef std::shared_ptr<SensorFrontend<ObservationType>> Ptr;
-    typedef std::shared_ptr<const SensorFrontend<ObservationType>> ConstPtr;
+    typedef std::shared_ptr<SensorFrontend<ObservationType, InfoType>> Ptr;
+    typedef std::shared_ptr<const SensorFrontend<ObservationType, InfoType>>
+        ConstPtr;
     typedef time_series::Timestamp TimeStamp;
     typedef time_series::Index TimeIndex;
 
-    SensorFrontend(std::shared_ptr<SensorData<ObservationType>> sensor_data)
+    SensorFrontend(
+        std::shared_ptr<SensorData<ObservationType, InfoType>> sensor_data)
         : sensor_data_(sensor_data)
     {
+    }
+
+    InfoType get_sensor_info() const
+    {
+        return sensor_data_->sensor_info->newest_element();
     }
 
     ObservationType get_observation(const TimeIndex t) const
@@ -63,7 +71,7 @@ public:
     }
 
 private:
-    std::shared_ptr<SensorData<ObservationType>> sensor_data_;
+    std::shared_ptr<SensorData<ObservationType, InfoType>> sensor_data_;
 };
 
 }  // namespace robot_interfaces

--- a/include/robot_interfaces/sensors/sensor_logger.hpp
+++ b/include/robot_interfaces/sensors/sensor_logger.hpp
@@ -43,11 +43,11 @@ namespace robot_interfaces
  *
  * @tparam Observation Typ of the observation that is recorded.
  */
-template <typename Observation>
+template <typename Observation, typename InfoType = None>
 class SensorLogger
 {
 public:
-    typedef std::shared_ptr<SensorData<Observation>> DataPtr;
+    typedef std::shared_ptr<SensorData<Observation, InfoType>> DataPtr;
     typedef typename std::tuple<double, Observation> StampedObservation;
 
     /**
@@ -89,7 +89,7 @@ public:
         {
             enabled_ = true;
             buffer_thread_ =
-                std::thread(&SensorLogger<Observation>::loop, this);
+                std::thread(&SensorLogger<Observation, InfoType>::loop, this);
         }
     }
 

--- a/include/robot_interfaces/utils.hpp
+++ b/include/robot_interfaces/utils.hpp
@@ -1,0 +1,25 @@
+/**
+ * @file
+ * @copyright 2020, New York University, Max Planck Gesellschaft. All rights
+ *            reserved.
+ * @license BSD-3-clause
+ */
+#pragma once
+
+#include <cstdint>
+
+namespace robot_interfaces
+{
+//! @brief Empty struct that can be used as placeholder.
+struct None
+{
+    template <class Archive>
+    void serialize(Archive& archive)
+    {
+        // need to serialize some dummy value here, as an actual empty type will
+        // cause trouble for our shared_memory implementation
+        uint8_t dummy = 0;
+        archive(dummy);
+    }
+};
+}  // namespace robot_interfaces

--- a/tests/test_sensor_logger.cpp
+++ b/tests/test_sensor_logger.cpp
@@ -12,6 +12,7 @@
 #include <robot_interfaces/sensors/sensor_frontend.hpp>
 #include <robot_interfaces/sensors/sensor_log_reader.hpp>
 #include <robot_interfaces/sensors/sensor_logger.hpp>
+#include <robot_interfaces/utils.hpp>
 
 #include "dummy_sensor_driver.hpp"
 
@@ -50,7 +51,7 @@ TEST_F(TestSensorLogger, write_and_read_log)
         auto driver =
             std::make_shared<robot_interfaces::testing::DummySensorDriver>();
         auto frontend = SensorFrontend<int>(data);
-        auto logger = SensorLogger<int>(data, BUFFER_LIMIT);
+        auto logger = SensorLogger<int, None>(data, BUFFER_LIMIT);
         logger.start();
 
         // create backend last to ensure no message is missed
@@ -90,7 +91,7 @@ TEST_F(TestSensorLogger, buffer_limit)
         auto frontend = SensorFrontend<int>(data);
 
         // set buffer
-        auto logger = SensorLogger<int>(data, BUFFER_LIMIT);
+        auto logger = SensorLogger<int, None>(data, BUFFER_LIMIT);
         logger.start();
 
         // create backend last to ensure no message is missed


### PR DESCRIPTION
## Description

Add a `sensor_info` field to `SensorData` which can be used to provide static information about the sensor to the user.  A method `get_sensor_info()` is added to `SensorDriver` to fill the field in the backend.  It can then be accessed via a method of the same name in `SensorFrontend`.

By default, it provides an empty struct for backward compatibility.

Use this for data that doesn't change between observations (e.g. calibration parameters of frame rate).  Changing values should be added to the observation instead.


## How I Tested

By implementing it in trifinger_cameras.
