### PR TITLE
chore: Bump versions in GitHub workflows

### DIFF
--- a/.github/workflows/build_master.yml
+++ b/.github/workflows/build_master.yml
@@ -18,7 +18,7 @@ on:
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     # Grant GITHUB_TOKEN the permissions required to make a Pages deployment
     permissions:
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Apptainer
         uses: open-dynamic-robot-initiative/trifinger-build-action/setup_apptainer@v2

--- a/.github/workflows/build_pr.yml
+++ b/.github/workflows/build_pr.yml
@@ -15,10 +15,10 @@ on: pull_request
 
 jobs:
   build_and_test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Apptainer
         uses: open-dynamic-robot-initiative/trifinger-build-action/setup_apptainer@v2

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,10 +5,10 @@ on: pull_request
 jobs:
   clang-format:
     name: C++ Formatting
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
       - run: wget https://raw.githubusercontent.com/machines-in-motion/mpi_cmake_modules/master/scripts/run-clang-format
       - run: wget https://raw.githubusercontent.com/machines-in-motion/mpi_cmake_modules/master/resources/_clang-format
       - run: python ./run-clang-format -r .

--- a/.github/workflows/pr_todo_checks.yml
+++ b/.github/workflows/pr_todo_checks.yml
@@ -7,7 +7,7 @@ jobs:
     name: New FIXMEs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check for FIXMEs
       uses: luator/github_action_check_new_todos@v2
       with:
@@ -18,7 +18,7 @@ jobs:
     name: New TODOs
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Check for TODOs
       uses: luator/github_action_check_new_todos@v2
       with:


### PR DESCRIPTION
- Use ubuntu-latest instead of ubuntu-20.04 (20.04 will be disabled soon).
- Bump actions/checkout and setup-python to latest versions.
