### PR TITLE
Add method `is_running()` to loggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
   coefficients, frame rate, etc.).  For this, a method `get_sensor_info()` is added to
   `SensorFrontend`.  It defaults to an empty struct for backward compatibility.  To use
   it, implement the method with the same name in `SensorDriver`.
+- Add `is_running()` to `RobotLogger` and `SensorLogger`.  Can, for example, be used to
+  detect if the buffer is full (in which case the logger stops automatically).
 
 ### Changed
 - The return type of `RobotDriver::get_error()` is changed to

--- a/include/robot_interfaces/pybind_helper.hpp
+++ b/include/robot_interfaces/pybind_helper.hpp
@@ -177,6 +177,9 @@ void create_robot_logger_python_bindings(pybind11::module &m)
         .def("stop_and_save",
              &Types::Logger::stop_and_save,
              pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("is_running",
+             &Types::Logger::is_running,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("reset",
              &Types::Logger::reset,
              pybind11::call_guard<pybind11::gil_scoped_release>())

--- a/include/robot_interfaces/robot_logger.hpp
+++ b/include/robot_interfaces/robot_logger.hpp
@@ -141,6 +141,17 @@ public:
         }
     }
 
+    /**
+     * @brief Check if the logger is currently running.
+     *
+     * After calling @ref start(), the logger is running until @ref stop() is
+     * called or the buffer is full (in which case it will stop automatically).
+     */
+    bool is_running() const
+    {
+        return enabled_;
+    }
+
     //! @brief Clear the log buffer.
     void reset()
     {

--- a/include/robot_interfaces/sensors/pybind_sensors.hpp
+++ b/include/robot_interfaces/sensors/pybind_sensors.hpp
@@ -94,6 +94,9 @@ void create_sensor_bindings(pybind11::module& m)
         .def("stop",
              &Logger::stop,
              pybind11::call_guard<pybind11::gil_scoped_release>())
+        .def("is_running",
+             &Logger::is_running,
+             pybind11::call_guard<pybind11::gil_scoped_release>())
         .def("reset",
              &Logger::reset,
              pybind11::call_guard<pybind11::gil_scoped_release>())

--- a/include/robot_interfaces/sensors/sensor_logger.hpp
+++ b/include/robot_interfaces/sensors/sensor_logger.hpp
@@ -107,6 +107,17 @@ public:
         }
     }
 
+    /**
+     * @brief Check if the logger is currently running.
+     *
+     * After calling @ref start(), the logger is running until @ref stop() is
+     * called or the buffer is full (in which case it will stop automatically).
+     */
+    bool is_running() const
+    {
+        return enabled_;
+    }
+
     //! @brief Clear the log buffer.
     void reset()
     {


### PR DESCRIPTION
To check if the logger is still running.  Can be used to automatically take some action (e.g. save and exit) when the buffer is full.