### PR TITLE
Make sensor data and buffer in SensorLogger protected

### DIFF
--- a/include/robot_interfaces/sensors/sensor_logger.hpp
+++ b/include/robot_interfaces/sensors/sensor_logger.hpp
@@ -146,9 +146,11 @@ public:
         archive(format_version, buffer_);
     }
 
-private:
+protected:
     DataPtr sensor_data_;
     std::vector<StampedObservation> buffer_;
+
+private:
     size_t buffer_limit_;
     std::thread buffer_thread_;
     bool enabled_;


### PR DESCRIPTION
This allows to derive classes that add functionality to save the data in different formats.
