### PR TITLE
Use real-time thread in SensorBackend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@
   joints in place).
 - If an error message given to `Status::set_error()` is cut due to being too
   long, this is now indicated by setting '~' as last character.
+- `SensorBackend` now uses a real-time thread like `RobotBackend` (previously it was
+  using a "normal" one).
 
 ### Fixed
 - pybind11 build error on Ubuntu 22.04

--- a/include/robot_interfaces/sensors/sensor_backend.hpp
+++ b/include/robot_interfaces/sensors/sensor_backend.hpp
@@ -8,10 +8,10 @@
 
 #pragma once
 
-#include <algorithm>
 #include <cmath>
-#include <cstdint>
 #include <thread>
+
+#include <real_time_tools/thread.hpp>
 
 #include <robot_interfaces/sensors/sensor_data.hpp>
 #include <robot_interfaces/sensors/sensor_driver.hpp>
@@ -45,14 +45,16 @@ public:
         std::shared_ptr<SensorData<ObservationType, InfoType>> sensor_data)
         : sensor_driver_(sensor_driver),
           sensor_data_(sensor_data),
+          loop_is_running_(false),
           shutdown_requested_(false)
     {
         // populate the sensor information field
         InfoType info = sensor_driver_->get_sensor_info();
         sensor_data_->sensor_info->append(info);
 
-        thread_ =
-            std::thread(&SensorBackend<ObservationType, InfoType>::loop, this);
+        thread_ = std::make_shared<real_time_tools::RealTimeThread>();
+        loop_is_running_ = true;
+        thread_->create_realtime_thread(&SensorBackend::loop, this);
     }
 
     // reinstate the implicit move constructor
@@ -63,9 +65,10 @@ public:
     void shutdown()
     {
         shutdown_requested_ = true;
-        if (thread_.joinable())
+
+        while (loop_is_running_)
         {
-            thread_.join();
+            real_time_tools::Timer::sleep_microseconds(100000);
         }
     }
 
@@ -78,9 +81,18 @@ private:
     std::shared_ptr<SensorDriver<ObservationType, InfoType>> sensor_driver_;
     std::shared_ptr<SensorData<ObservationType, InfoType>> sensor_data_;
 
+    //! @brief Indicates if the background loop is still running.
+    std::atomic<bool> loop_is_running_;
+
     bool shutdown_requested_;
 
-    std::thread thread_;
+    std::shared_ptr<real_time_tools::RealTimeThread> thread_;
+
+    static void *loop(void *instance_pointer)
+    {
+        ((SensorBackend *)(instance_pointer))->loop();
+        return nullptr;
+    }
 
     /**
      * @brief Main loop.
@@ -100,6 +112,8 @@ private:
             }
             sensor_data_->observation->append(sensor_observation);
         }
+
+        loop_is_running_ = false;
     }
 };
 


### PR DESCRIPTION
## Description

Even if the sensor itself may not be fully real-time capable (e.g. due to USB connection), it might still help to reduce timing variations.


## How I Tested

By recording tricamera log files and analysing the timing in them.
I observed that with the real-time thread, there are a few delay spikes that are larger as without but overall the timing is much more constant than with a normal thread:

The plots show the difference between camera timestamps of consecutive observations.

With regular threads (old behaviour):
<img width="1905" height="921" alt="old_2" src="https://github.com/user-attachments/assets/f281a945-7b19-46aa-98b3-f95b3f9add47" />

With real-time thread (this PR):
<img width="1905" height="921" alt="new_rt_2" src="https://github.com/user-attachments/assets/75f4f3d3-f006-4880-96d2-dfe3995f83ca" />

I'm not sure why the max spikes are larger in the RT case but since they are few, I think it's better than the overall inconsistent timing of the old implementation.  Anyway, I'll further investigate.